### PR TITLE
reasonReference in stu3

### DIFF
--- a/Profiles - ZIB 2017/Extensions and base profiles/extension-reasonReference-stu3.xml
+++ b/Profiles - ZIB 2017/Extensions and base profiles/extension-reasonReference-stu3.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="reasonReference-stu3" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/reasonReference-stu3" />
+  <version value="1.0.0" />
+  <name value="reasonReference" />
+  <title value="reasonReference" />
+  <status value="draft" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="email" />
+      <value value="info@nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="Reason reference on a DeviceUseStatement.&#xD;&#xA;Extension is mocked from the offical HL7 core of DeviceUseStatement in R4 FHIR build specification at 01-05-2019." />
+  <copyright value="CC0" />
+  <fhirVersion value="3.0.1" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <contextType value="resource" />
+  <context value="DeviceUseStatement" />
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension">
+      <path value="Extension" />
+      <short value="Indicates another resource whose existence justifies this DeviceUseStatement." />
+      <definition value="Indicates another resource whose existence justifies this DeviceUseStatement." />
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/reasonReference-stu3" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.valueReference" />
+      <short value="Another resource whose existence justifies this DeviceUseStatement." />
+      <definition value="Another resource whose existence justifies this DeviceUseStatement." />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+      </type>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Condition" />
+      </type>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Observation" />
+      </type>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" />
+      </type>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DocumentReference" />
+      </type>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Media" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/Profiles - ZIB 2017/Extensions and base profiles/extension-reasonReference-stu3.xml
+++ b/Profiles - ZIB 2017/Extensions and base profiles/extension-reasonReference-stu3.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="reasonReference-stu3" />
-  <url value="http://nictiz.nl/fhir/StructureDefinition/reasonReference-stu3" />
+  <id value="DeviceUseStatement-reasonReference-stu3" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/DeviceUseStatement-reasonReference-stu3" />
   <version value="1.0.0" />
-  <name value="reasonReference" />
-  <title value="reasonReference" />
+  <name value="DeviceUseStatement-reasonReference-stu3" />
+  <title value="DeviceUseStatement reasonReference STU3" />
   <status value="draft" />
   <publisher value="Nictiz" />
   <contact>
@@ -28,21 +28,17 @@
   <differential>
     <element id="Extension">
       <path value="Extension" />
-      <short value="Indicates another resource whose existence justifies this DeviceUseStatement." />
-      <definition value="Indicates another resource whose existence justifies this DeviceUseStatement." />
+      <short value="Why was DeviceUseStatement performed?" />
+      <definition value="Another resource whose existence justifies this DeviceUseStatement." />
     </element>
     <element id="Extension.url">
       <path value="Extension.url" />
-      <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/reasonReference-stu3" />
+      <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/DeviceUseStatement-reasonReference-stu3" />
     </element>
     <element id="Extension.value[x]">
       <path value="Extension.valueReference" />
-      <short value="Another resource whose existence justifies this DeviceUseStatement." />
+      <short value="Why was DeviceUseStatement performed?" />
       <definition value="Another resource whose existence justifies this DeviceUseStatement." />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
-      </type>
       <type>
         <code value="Reference" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Condition" />

--- a/Profiles - ZIB 2017/zib-MedicalDevice.xml
+++ b/Profiles - ZIB 2017/zib-MedicalDevice.xml
@@ -133,6 +133,15 @@
       <path value="DeviceUseStatement.extension.valueReference" />
       <sliceName value="valueReference" />
     </element>
+    <element id="DeviceUseStatement.extension:reasonReference">
+      <path value="DeviceUseStatement.extension" />
+      <sliceName value="reasonReference" />
+      <definition value="Indicates another resource whose existence justifies this DeviceUseStatement. This extension is backported from the offical HL7 DeviceUseStatement specification in FHIR R4." />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/reasonReference-stu3" />
+      </type>
+    </element>
     <element id="DeviceUseStatement.identifier">
       <path value="DeviceUseStatement.identifier" />
       <mapping>

--- a/Profiles - ZIB 2017/zib-MedicalDevice.xml
+++ b/Profiles - ZIB 2017/zib-MedicalDevice.xml
@@ -136,10 +136,10 @@
     <element id="DeviceUseStatement.extension:reasonReference">
       <path value="DeviceUseStatement.extension" />
       <sliceName value="reasonReference" />
-      <definition value="Indicates another resource whose existence justifies this DeviceUseStatement. This extension is backported from the offical HL7 DeviceUseStatement specification in FHIR R4." />
+      <comment value="This extension is backported from the offical HL7 DeviceUseStatement specification in FHIR R4." />
       <type>
         <code value="Extension" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/reasonReference-stu3" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/DeviceUseStatement-reasonReference-stu3" />
       </type>
     </element>
     <element id="DeviceUseStatement.identifier">


### PR DESCRIPTION

Implemented the FHIR R4 reasonReference field in DeviceUseStatement to the STU3 version of HCIM MedicalDevice (FHIR DeviceUseStatement)