### PR TITLE
Mm 778

### DIFF
--- a/Profiles - ZIB 2017/conceptmap-AdresSoortCodelijst-to-AddressType.xml
+++ b/Profiles - ZIB 2017/conceptmap-AdresSoortCodelijst-to-AddressType.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+    <valueBoolean value="false"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/AdresSoortCodelijst-to-AddressType"/>
     <version value="1.0.0"/>
     <name value="AdresSoortCodelijst-to-AddressType"/>

--- a/Profiles - ZIB 2017/conceptmap-AdresSoortCodelijst-to-AddressUse.xml
+++ b/Profiles - ZIB 2017/conceptmap-AdresSoortCodelijst-to-AddressUse.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="false"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/AdresSoortCodelijst-to-AddressUse"/>
     <version value="1.0.0"/>
     <name value="AdresSoortCodelijst-to-AddressUse"/>

--- a/Profiles - ZIB 2017/conceptmap-AllergieCategorieCodelijst-to-allergy-intolerance-category.xml
+++ b/Profiles - ZIB 2017/conceptmap-AllergieCategorieCodelijst-to-allergy-intolerance-category.xml
@@ -1,5 +1,8 @@
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="false"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/AllergieCategorieCodelijst-to-allergy-intolerance-category"/>
     <version value="2.0.0"/>
     <name value="AllergieCategorieCodelijst-to-allergy-intolerance-category"/>

--- a/Profiles - ZIB 2017/conceptmap-AllergieStatusCodelijst-to-allergy-clinical-status.xml
+++ b/Profiles - ZIB 2017/conceptmap-AllergieStatusCodelijst-to-allergy-clinical-status.xml
@@ -1,5 +1,8 @@
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="false"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/AllergieStatusCodelijst-to-allergy-status"/>
     <version value="2.0.0"/>
     <name value="AllergieStatusCodelijst-to-allergy-status"/>

--- a/Profiles - ZIB 2017/conceptmap-Condition-ClinicalStatusCodelijst-To-ProblemStatusCodelijst.xml
+++ b/Profiles - ZIB 2017/conceptmap-Condition-ClinicalStatusCodelijst-To-ProblemStatusCodelijst.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="false"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/Condition-Clinical-Status-Codes-to-ProbleemStatusCodelijst" />
     <version value="2.0.0" />
     <name value="Condition-Clinical-Status-Codes-to-ProbleemStatusCodelijst" />

--- a/Profiles - ZIB 2017/conceptmap-ContactTypeCodelijst-to-ActEncounterCode.xml
+++ b/Profiles - ZIB 2017/conceptmap-ContactTypeCodelijst-to-ActEncounterCode.xml
@@ -1,5 +1,8 @@
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="true"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/ContactTypeCodelijst-to-ActEncounterCode"/>
     <version value="2.0.0"/>
     <name value="ContactTypeCodelijst-to-ActEncounterCode"/>

--- a/Profiles - ZIB 2017/conceptmap-EmailSoortCodelijst-to-ContactPointSystem.xml
+++ b/Profiles - ZIB 2017/conceptmap-EmailSoortCodelijst-to-ContactPointSystem.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="false"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactPointSystem"/>
     <version value="1.0.0"/>
     <name value="EmailSoortCodelijst-to-ContactPointSystem"/>

--- a/Profiles - ZIB 2017/conceptmap-EmailSoortCodelijst-to-ContactPointUse.xml
+++ b/Profiles - ZIB 2017/conceptmap-EmailSoortCodelijst-to-ContactPointUse.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="true"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactPointUse"/>
     <version value="1.0.0"/>
     <name value="EmailSoortCodelijst-to-ContactPointUse"/>

--- a/Profiles - ZIB 2017/conceptmap-ErnstCodelijst-to-AllergyIntoleranceSeverity.xml
+++ b/Profiles - ZIB 2017/conceptmap-ErnstCodelijst-to-AllergyIntoleranceSeverity.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+  <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+    <valueBoolean value="true"/>
+  </extension>
   <url value="http://nictiz.nl/fhir/ConceptMap/ErnstCodelijst-to-AllergyIntoleranceSeverity"/>
   <version value="2.0.0"/>
   <name value="ErnstCodelijst-to-AllergyIntoleranceSeverity"/>

--- a/Profiles - ZIB 2017/conceptmap-GeslachtCodelijst-to-AdministrativeGender.xml
+++ b/Profiles - ZIB 2017/conceptmap-GeslachtCodelijst-to-AdministrativeGender.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="false"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/GeslachtCodelijst-to-AdministrativeGender"/>
     <version value="1.0.0"/>
     <name value="GeslachtCodelijst-to-AdministrativeGender"/>

--- a/Profiles - ZIB 2017/conceptmap-InterpretatieVlaggenCodelijst-To-Observation-Interpretation.xml
+++ b/Profiles - ZIB 2017/conceptmap-InterpretatieVlaggenCodelijst-To-Observation-Interpretation.xml
@@ -1,5 +1,8 @@
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="true"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/InterpretatieVlaggenCodelijst-to-observation-interpretation"/>
     <version value="2.0.2"/>
     <name value="InterpretatieVlaggenCodelijst-to-observation-interpretation"/>

--- a/Profiles - ZIB 2017/conceptmap-MateVanKritiekZijnCodelijst-to-allergy-intolerance-criticality.xml
+++ b/Profiles - ZIB 2017/conceptmap-MateVanKritiekZijnCodelijst-to-allergy-intolerance-criticality.xml
@@ -1,5 +1,8 @@
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="false"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/MateVanKritiekZijnCodelijst-to-allergy-intolerance-criticality"/>
     <version value="2.0.0"/>
     <name value="MateVanKritiekZijnCodelijst-to-allergy-intolerance-criticality"/>

--- a/Profiles - ZIB 2017/conceptmap-NHGTable14-to-ActEncounterCode.xml
+++ b/Profiles - ZIB 2017/conceptmap-NHGTable14-to-ActEncounterCode.xml
@@ -1,5 +1,8 @@
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="false"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/NHGTable14-to-ActEncounterCode"/>
     <version value="1.0.0"/>
     <name value="NHGTable14-to-ActEncounterCode"/>

--- a/Profiles - ZIB 2017/conceptmap-NaamgebruikCodelijst-to-HumanNameAssemblyOrder.xml
+++ b/Profiles - ZIB 2017/conceptmap-NaamgebruikCodelijst-to-HumanNameAssemblyOrder.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="true"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/NaamgebruikCodelijst-to-HumanNameAssemblyOrder"/>
     <version value="1.0.0"/>
     <name value="NaamgebruikCodelijst-to-HumanNameAssemblyOrder"/>

--- a/Profiles - ZIB 2017/conceptmap-NummerSoortCodelijst-to-ContactPointUse.xml
+++ b/Profiles - ZIB 2017/conceptmap-NummerSoortCodelijst-to-ContactPointUse.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="true"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/NummerSoortCodelijst-to-ContactPointUse"/>
     <version value="1.0.0"/>
     <name value="NummerSoortCodelijst-to-ContactPointUse"/>

--- a/Profiles - ZIB 2017/conceptmap-ProbleemStatusCodelijst-To-Condition-Clinical-Status-Codes.xml
+++ b/Profiles - ZIB 2017/conceptmap-ProbleemStatusCodelijst-To-Condition-Clinical-Status-Codes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+  <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+    <valueBoolean value="false"/>
+  </extension>
   <url value="http://nictiz.nl/fhir/ConceptMap/ProbleemStatusCodelijst-to-Condition-Clinical-Status-Codes"/>
   <version value="2.1.0"/>
   <name value="ProbleemStatusCodelijst-to-Condition-Clinical-Status-Codes"/>

--- a/Profiles - ZIB 2017/conceptmap-TelecomSoortCodelijst-to-ContactPointSystem.xml
+++ b/Profiles - ZIB 2017/conceptmap-TelecomSoortCodelijst-to-ContactPointSystem.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="false"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/TelecomSoortCodelijst-to-ContactPointSystem"/>
     <version value="1.0.1"/>
     <name value="TelecomSoortCodelijst-to-ContactPointSystem"/>

--- a/Profiles - ZIB 2017/conceptmap-TelecomSoortCodelijst-to-ContactPointUse.xml
+++ b/Profiles - ZIB 2017/conceptmap-TelecomSoortCodelijst-to-ContactPointUse.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="true"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/TelecomSoortCodelijst-to-ContactPointUse"/>
     <version value="1.0.0"/>
     <name value="TelecomSoortCodelijst-to-ContactPointUse"/>

--- a/Profiles - ZIB 2017/conceptmap-VerificatieStatusCodelijst-to-ConditionVerificationStatus.xml
+++ b/Profiles - ZIB 2017/conceptmap-VerificatieStatusCodelijst-to-ConditionVerificationStatus.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/conceptmap.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <ConceptMap xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/conceptmap.xsd">
+    <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
+        <valueBoolean value="true"/>
+    </extension>
     <url value="http://nictiz.nl/fhir/ConceptMap/VerificatieStatusCodelijst-to-ConditionVerificationStatus"/>
     <version value="1.0"/>
     <name value="VerificatieStatusCodelijst-to-ConditionVerificationStatus"/>

--- a/Profiles - ZIB 2017/gp-Encounter.xml
+++ b/Profiles - ZIB 2017/gp-Encounter.xml
@@ -27,40 +27,6 @@
       <path value="Encounter.class" />
       <definition value="The type of contact. Normally ambulatory or home visit." />
     </element>
-    <element id="Encounter.class.extension">
-      <path value="Encounter.class.extension" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="url" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Encounter.class.extension:ContactTypeCodelijst">
-      <path value="Encounter.class.extension" />
-      <sliceName value="ContactTypeCodelijst" />
-      <short value="ActEncounter" />
-      <definition value="The type of contact. Normally ambulatory or home visit, use this extension to include the original ZIB code" />
-      <alias value="ContactTypeCodelijst" />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
-      </type>
-    </element>
-    <element id="Encounter.class.extension:ContactTypeCodelijst.valueCodeableConcept:valueCodeableConcept">
-      <path value="Encounter.class.extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
-      <binding>
-        <strength value="extensible" />
-        <description value="ContactTypeCodelijst" />
-        <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.15.1.1--20171231000000" />
-          <display value="ContactTypeCodelijst" />
-        </valueSetReference>
-      </binding>
-    </element>
     <element id="Encounter.type">
       <path value="Encounter.type" />
       <definition value="The type of encounter as defined in NHG Table 14 ContactWijze" />

--- a/Profiles - ZIB 2017/gp-Encounter.xml
+++ b/Profiles - ZIB 2017/gp-Encounter.xml
@@ -27,6 +27,40 @@
       <path value="Encounter.class" />
       <definition value="The type of contact. Normally ambulatory or home visit." />
     </element>
+    <element id="Encounter.class.extension">
+      <path value="Encounter.class.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Encounter.class.extension:ContactTypeCodelijst">
+      <path value="Encounter.class.extension" />
+      <sliceName value="ContactTypeCodelijst" />
+      <short value="ActEncounter" />
+      <definition value="The type of contact. Normally ambulatory or home visit, use this extension to include the original ZIB code" />
+      <alias value="ContactTypeCodelijst" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+      </type>
+    </element>
+    <element id="Encounter.class.extension:ContactTypeCodelijst.valueCodeableConcept:valueCodeableConcept">
+      <path value="Encounter.class.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="ContactTypeCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.15.1.1--20171231000000" />
+          <display value="ContactTypeCodelijst" />
+        </valueSetReference>
+      </binding>
+    </element>
     <element id="Encounter.type">
       <path value="Encounter.type" />
       <definition value="The type of encounter as defined in NHG Table 14 ContactWijze" />

--- a/Profiles - ZIB 2017/nl-core-address.xml
+++ b/Profiles - ZIB 2017/nl-core-address.xml
@@ -203,7 +203,7 @@
       <path value="Address.use.extension" />
       <sliceName value="AD_use" />
       <short value="Further define the address use with the exact HCIM code." />
-      <definition value="Further define the address use with the exact HCIM code. Mostly relevant to distinguish between different types of temporasry addresses." />
+      <definition value="Further define the address use with the exact HCIM code. Mostly relevant to distinguish between different types of temporary addresses. TMP and WP are not included in the valueset address-use but can be included through this extension" />
       <alias value="Precieze definiëring van adressoort op basis van exacte zib-code" />
       <type>
         <code value="Extension" />

--- a/Profiles - ZIB 2017/nl-core-contactpoint.xml
+++ b/Profiles - ZIB 2017/nl-core-contactpoint.xml
@@ -459,6 +459,74 @@
         <comment value="EmailAddressType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactPointSystem" />
       </mapping>
     </element>
+    <element id="ContactPoint.system.extension">
+      <path value="ContactPoint.system.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="ContactPoint.system.extension:EmailSoortCodelijst">
+      <path value="ContactPoint.system.extension" />
+      <sliceName value="EmailSoortCodelijst" />
+      <short value="EmailSoortCodelijst" />
+      <definition value="" />
+      <alias value="EmailSoortCodelijst" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+      </type>
+      <mapping>
+        <identity value="hcim-contactinformation-v1.0-2017EN" />
+        <map value="NL-CM:20.6.8" />
+        <comment value="EmailAddressType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactPointSystem" />
+      </mapping>
+    </element>
+    <element id="ContactPoint.system.extension:EmailSoortCodelijst.valueCodeableConcept:valueCodeableConcept">
+      <path value="ContactPoint.system.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="EmailSoortCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.3--20171231000000" />
+          <display value="EmailSoortCodelijst" />
+        </valueSetReference>
+      </binding>
+    </element>
+    <element id="ContactPoint.system.extension:TelecomSoortCodelijst">
+      <path value="ContactPoint.system.extension" />
+      <sliceName value="TelecomSoortCodelijst" />
+      <short value="TelecomSoortCodelijst" />
+      <definition value="" />
+      <alias value="TelecomSoortCodelijst" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+      </type>
+      <mapping>
+        <identity value="hcim-contactinformation-v1.0-2017EN" />
+        <map value="NL-CM:20.6.5" />
+        <comment value="TelecomType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/TelecomSoortCodelijst-to-ContactPointSystem" />
+      </mapping>
+    </element>
+    <element id="ContactPoint.system.extension:TelecomSoortCodelijst.valueCodeableConcept:valueCodeableConcept">
+      <path value="ContactPoint.system.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="TelecomSoortCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.1--20171231000000" />
+          <display value="TelecomSoortCodelijst" />
+        </valueSetReference>
+      </binding>
+    </element>    
     <element id="ContactPoint.value">
       <path value="ContactPoint.value" />
       <short value="TelephoneNumber / EmailAddress" />
@@ -543,5 +611,102 @@
         <comment value="EmailAddressType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactPointUse" />
       </mapping>
     </element>
+    <element id="ContactPoint.use.extension">
+      <path value="ContactPoint.use.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="ContactPoint.use.extension:EmailSoortCodelijst">
+      <path value="ContactPoint.use.extension" />
+      <sliceName value="EmailSoortCodelijst" />
+      <short value="EmailSoortCodelijst" />
+      <definition value="" />
+      <alias value="EmailSoortCodelijst" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+      </type>
+      <mapping>
+        <identity value="hcim-contactinformation-v1.0-2017EN" />
+        <map value="NL-CM:20.6.8" />
+        <comment value="EmailAddressType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactPointValue" />
+      </mapping>
+    </element>
+    <element id="ContactPoint.use.extension:EmailSoortCodelijst.valueCodeableConcept:valueCodeableConcept">
+      <path value="ContactPoint.use.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="EmailSoortCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.3--20171231000000" />
+          <display value="EmailSoortCodelijst" />
+        </valueSetReference>
+      </binding>
+    </element>
+    <element id="ContactPoint.use.extension:TelecomSoortCodelijst">
+        <path value="ContactPoint.use.extension" />
+        <sliceName value="TelecomSoortCodelijst" />
+        <short value="TelecomSoortCodelijst" />
+        <definition value="" />
+        <alias value="TelecomSoortCodelijst" />
+        <max value="1" />
+        <type>
+          <code value="Extension" />
+          <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+        </type>
+        <mapping>
+          <identity value="hcim-contactinformation-v1.0-2017EN" />
+          <map value="NL-CM:20.6.5" />
+          <comment value="TelecomType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/TelecomSoortCodelijst-to-ContactPointValue" />
+        </mapping>
+    </element>
+    <element id="ContactPoint.use.extension:TelecomSoortCodelijst.valueCodeableConcept:valueCodeableConcept">
+        <path value="ContactPoint.use.extension.valueCodeableConcept" />
+        <sliceName value="valueCodeableConcept" />
+        <binding>
+          <strength value="extensible" />
+          <description value="TelecomSoortCodelijst" />
+          <valueSetReference>
+            <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.1--20171231000000" />
+            <display value="TelecomSoortCodelijst" />
+          </valueSetReference>
+        </binding>
+    </element>      
+    <element id="ContactPoint.use.extension:NummerSoortCodelijst">
+        <path value="ContactPoint.use.extension" />
+        <sliceName value="NummerSoortCodelijst" />
+        <short value="NummerSoortCodelijst" />
+        <definition value="" />
+        <alias value="NummerSoortCodelijst" />
+        <max value="1" />
+        <type>
+          <code value="Extension" />
+          <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+        </type>
+        <mapping>
+          <identity value="hcim-contactinformation-v1.0-2017EN" />
+          <map value="NL-CM:20.6.6" />
+          <comment value="TelecomType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/NummerSoortCodelijst-to-ContactPointValue" />
+        </mapping>
+      </element>
+      <element id="ContactPoint.use.extension:NummerSoortCodelijst.valueCodeableConcept:valueCodeableConcept">
+        <path value="ContactPoint.use.extension.valueCodeableConcept" />
+        <sliceName value="valueCodeableConcept" />
+        <binding>
+          <strength value="extensible" />
+          <description value="NummerSoortCodelijst" />
+          <valueSetReference>
+            <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.2--20171231000000" />
+            <display value="NummerSoortCodelijst" />
+          </valueSetReference>
+        </binding>
+    </element> 
   </differential>
 </StructureDefinition>

--- a/Profiles - ZIB 2017/nl-core-contactpoint.xml
+++ b/Profiles - ZIB 2017/nl-core-contactpoint.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="nl-core-contactpoint" />
   <url value="http://fhir.nl/fhir/StructureDefinition/nl-core-contactpoint" />
-  <version value="1.0.1" />
+  <version value="1.0.2" />
   <name value="nl-core-contactpoint" />
   <title value="nl-core-contactpoint" />
   <status value="active" />
@@ -469,24 +469,17 @@
         <rules value="open" />
       </slicing>
     </element>
-    <element id="ContactPoint.system.extension:EmailSoortCodelijst">
+    <element id="ContactPoint.system.extension:EmailAddressTypeCodelist">
       <path value="ContactPoint.system.extension" />
-      <sliceName value="EmailSoortCodelijst" />
-      <short value="EmailSoortCodelijst" />
-      <definition value="" />
+      <sliceName value="EmailAddressTypeCodelist" />
+      <short value="EmailAddressTypeCodelist" />
       <alias value="EmailSoortCodelijst" />
-      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
       </type>
-      <mapping>
-        <identity value="hcim-contactinformation-v1.0-2017EN" />
-        <map value="NL-CM:20.6.8" />
-        <comment value="EmailAddressType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactPointSystem" />
-      </mapping>
     </element>
-    <element id="ContactPoint.system.extension:EmailSoortCodelijst.valueCodeableConcept:valueCodeableConcept">
+    <element id="ContactPoint.system.extension:EmailAddressTypeCodelist.valueCodeableConcept:valueCodeableConcept">
       <path value="ContactPoint.system.extension.valueCodeableConcept" />
       <sliceName value="valueCodeableConcept" />
       <binding>
@@ -497,25 +490,24 @@
           <display value="EmailSoortCodelijst" />
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="hcim-contactinformation-v1.0-2017EN" />
+        <map value="NL-CM:20.6.8" />
+        <comment value="EmailAddressType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactPointSystem" />
+      </mapping>
     </element>
-    <element id="ContactPoint.system.extension:TelecomSoortCodelijst">
+    <element id="ContactPoint.system.extension:TelecomTypeCodelist">
       <path value="ContactPoint.system.extension" />
-      <sliceName value="TelecomSoortCodelijst" />
-      <short value="TelecomSoortCodelijst" />
-      <definition value="" />
+      <sliceName value="TelecomTypeCodelist" />
+      <short value="TelecomTypeCodelist" />
       <alias value="TelecomSoortCodelijst" />
       <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
       </type>
-      <mapping>
-        <identity value="hcim-contactinformation-v1.0-2017EN" />
-        <map value="NL-CM:20.6.5" />
-        <comment value="TelecomType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/TelecomSoortCodelijst-to-ContactPointSystem" />
-      </mapping>
     </element>
-    <element id="ContactPoint.system.extension:TelecomSoortCodelijst.valueCodeableConcept:valueCodeableConcept">
+    <element id="ContactPoint.system.extension:TelecomTypeCodelist.valueCodeableConcept:valueCodeableConcept">
       <path value="ContactPoint.system.extension.valueCodeableConcept" />
       <sliceName value="valueCodeableConcept" />
       <binding>
@@ -526,7 +518,12 @@
           <display value="TelecomSoortCodelijst" />
         </valueSetReference>
       </binding>
-    </element>    
+      <mapping>
+        <identity value="hcim-contactinformation-v1.0-2017EN" />
+        <map value="NL-CM:20.6.5" />
+        <comment value="TelecomType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/TelecomSoortCodelijst-to-ContactPointSystem" />
+      </mapping>
+    </element>
     <element id="ContactPoint.value">
       <path value="ContactPoint.value" />
       <short value="TelephoneNumber / EmailAddress" />
@@ -621,24 +618,17 @@
         <rules value="open" />
       </slicing>
     </element>
-    <element id="ContactPoint.use.extension:EmailSoortCodelijst">
+    <element id="ContactPoint.use.extension:EmailAddressTypeCodelist">
       <path value="ContactPoint.use.extension" />
-      <sliceName value="EmailSoortCodelijst" />
-      <short value="EmailSoortCodelijst" />
-      <definition value="" />
+      <sliceName value="EmailAddressTypeCodelist" />
+      <short value="EmailAddressTypeCodelist" />
       <alias value="EmailSoortCodelijst" />
-      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
       </type>
-      <mapping>
-        <identity value="hcim-contactinformation-v1.0-2017EN" />
-        <map value="NL-CM:20.6.8" />
-        <comment value="EmailAddressType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactPointValue" />
-      </mapping>
     </element>
-    <element id="ContactPoint.use.extension:EmailSoortCodelijst.valueCodeableConcept:valueCodeableConcept">
+    <element id="ContactPoint.use.extension:EmailAddressTypeCodelist.valueCodeableConcept:valueCodeableConcept">
       <path value="ContactPoint.use.extension.valueCodeableConcept" />
       <sliceName value="valueCodeableConcept" />
       <binding>
@@ -649,64 +639,70 @@
           <display value="EmailSoortCodelijst" />
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="hcim-contactinformation-v1.0-2017EN" />
+        <map value="NL-CM:20.6.8" />
+        <comment value="EmailAddressType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactPointValue" />
+      </mapping>
     </element>
-    <element id="ContactPoint.use.extension:TelecomSoortCodelijst">
-        <path value="ContactPoint.use.extension" />
-        <sliceName value="TelecomSoortCodelijst" />
-        <short value="TelecomSoortCodelijst" />
-        <definition value="" />
-        <alias value="TelecomSoortCodelijst" />
-        <max value="1" />
-        <type>
-          <code value="Extension" />
-          <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
-        </type>
-        <mapping>
-          <identity value="hcim-contactinformation-v1.0-2017EN" />
-          <map value="NL-CM:20.6.5" />
-          <comment value="TelecomType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/TelecomSoortCodelijst-to-ContactPointValue" />
-        </mapping>
+    <element id="ContactPoint.use.extension:TelecomTypeCodelist">
+      <path value="ContactPoint.use.extension" />
+      <sliceName value="TelecomTypeCodelist" />
+      <short value="TelecomTypeCodelist" />
+      <alias value="TelecomSoortCodelijst" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+      </type>
+      <mapping>
+        <identity value="hcim-contactinformation-v1.0-2017EN" />
+        <map value="NL-CM:20.6.5" />
+        <comment value="TelecomType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/TelecomSoortCodelijst-to-ContactPointValue" />
+      </mapping>
     </element>
-    <element id="ContactPoint.use.extension:TelecomSoortCodelijst.valueCodeableConcept:valueCodeableConcept">
-        <path value="ContactPoint.use.extension.valueCodeableConcept" />
-        <sliceName value="valueCodeableConcept" />
-        <binding>
-          <strength value="extensible" />
-          <description value="TelecomSoortCodelijst" />
-          <valueSetReference>
-            <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.1--20171231000000" />
-            <display value="TelecomSoortCodelijst" />
-          </valueSetReference>
-        </binding>
-    </element>      
-    <element id="ContactPoint.use.extension:NummerSoortCodelijst">
-        <path value="ContactPoint.use.extension" />
-        <sliceName value="NummerSoortCodelijst" />
-        <short value="NummerSoortCodelijst" />
-        <definition value="" />
-        <alias value="NummerSoortCodelijst" />
-        <max value="1" />
-        <type>
-          <code value="Extension" />
-          <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
-        </type>
-        <mapping>
-          <identity value="hcim-contactinformation-v1.0-2017EN" />
-          <map value="NL-CM:20.6.6" />
-          <comment value="TelecomType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/NummerSoortCodelijst-to-ContactPointValue" />
-        </mapping>
-      </element>
-      <element id="ContactPoint.use.extension:NummerSoortCodelijst.valueCodeableConcept:valueCodeableConcept">
-        <path value="ContactPoint.use.extension.valueCodeableConcept" />
-        <sliceName value="valueCodeableConcept" />
-        <binding>
-          <strength value="extensible" />
-          <description value="NummerSoortCodelijst" />
-          <valueSetReference>
-            <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.2--20171231000000" />
-            <display value="NummerSoortCodelijst" />
-          </valueSetReference>
-        </binding>
-    </element> 
+    <element id="ContactPoint.use.extension:TelecomTypeCodelist.valueCodeableConcept:valueCodeableConcept">
+      <path value="ContactPoint.use.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="TelecomSoortCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.1--20171231000000" />
+          <display value="TelecomSoortCodelijst" />
+        </valueSetReference>
+      </binding>
+      <mapping>
+        <identity value="hcim-contactinformation-v1.0-2017EN" />
+        <map value="NL-CM:20.6.5" />
+        <comment value="TelecomType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/TelecomSoortCodelijst-to-ContactPointValue" />
+      </mapping>
+    </element>
+    <element id="ContactPoint.use.extension:NumberTypeCodelist">
+      <path value="ContactPoint.use.extension" />
+      <sliceName value="NumberTypeCodelist" />
+      <short value="NumberTypeCodelist" />
+      <alias value="NummerSoortCodelijst" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+      </type>
+    </element>
+    <element id="ContactPoint.use.extension:NumberTypeCodelist.valueCodeableConcept:valueCodeableConcept">
+      <path value="ContactPoint.use.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="NummerSoortCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.2--20171231000000" />
+          <display value="NummerSoortCodelijst" />
+        </valueSetReference>
+      </binding>
+      <mapping>
+        <identity value="hcim-contactinformation-v1.0-2017EN" />
+        <map value="NL-CM:20.6.6" />
+        <comment value="TelecomType. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/NummerSoortCodelijst-to-ContactPointValue" />
+      </mapping>
+    </element>
   </differential>
 </StructureDefinition>

--- a/Profiles - ZIB 2017/zib-AllergyIntolerance.xml
+++ b/Profiles - ZIB 2017/zib-AllergyIntolerance.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="zib-AllergyIntolerance" />
   <url value="http://nictiz.nl/fhir/StructureDefinition/zib-AllergyIntolerance" />
-  <version value="2.1.3" />
+  <version value="2.1.4" />
   <name value="Zib AllergyIntolerance" />
   <title value="HCIM AllergyIntolerance" />
   <status value="active" />
@@ -807,6 +807,50 @@ The HCIM defines certain allergy statuses in the AllergieStatusCodelijst. These 
         <identity value="hcim-allergyintolerance-v3.2-2017EN" />
         <map value="NL-CM:8.2.14" />
         <comment value="Severity. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/ErnstCodelijst-to-AllergyIntoleranceSeverity" />
+      </mapping>
+    </element>
+    <element id="AllergyIntolerance.reaction.severity.extension">
+      <path value="AllergyIntolerance.reaction.severity.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="AllergyIntolerance.reaction.severity.extension:SeverityCodelist">
+      <path value="AllergyIntolerance.reaction.severity.extension" />
+      <sliceName value="SeverityCodelist" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+      </type>
+    </element>
+    <element id="AllergyIntolerance.reaction.severity.extension:SeverityCodelist.valueCodeableConcept:valueCodeableConcept">
+      <path value="AllergyIntolerance.reaction.severity.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="ErnstCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.8.2.6--20171231000000" />
+        </valueSetReference>
+      </binding>
+      <mapping>
+        <identity value="hcim-allergyintolerance-v1.0.2-2015EN" />
+        <map value="NL-CM:8.2.14" />
+        <comment value="Severity" />
+      </mapping>
+      <mapping>
+        <identity value="hcim-allergyintolerance-v3.0-2016EN" />
+        <map value="NL-CM:8.2.14" />
+        <comment value="Severity" />
+      </mapping>
+      <mapping>
+        <identity value="hcim-allergyintolerance-v3.2-2017EN" />
+        <map value="NL-CM:8.2.14" />
+        <comment value="Severity" />
       </mapping>
     </element>
     <element id="AllergyIntolerance.reaction.exposureRoute">

--- a/Profiles - ZIB 2017/zib-AllergyIntolerance.xml
+++ b/Profiles - ZIB 2017/zib-AllergyIntolerance.xml
@@ -809,55 +809,6 @@ The HCIM defines certain allergy statuses in the AllergieStatusCodelijst. These 
         <comment value="Severity. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/ErnstCodelijst-to-AllergyIntoleranceSeverity" />
       </mapping>
     </element>
-    <element id="AllergyIntolerance.reaction.severity.extension">
-      <path value="AllergyIntolerance.reaction.severity.extension" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="url" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="AllergyIntolerance.reaction.severity.extension:ErnstCodelijst">
-      <path value="AllergyIntolerance.reaction.severity.extension" />
-      <sliceName value="ErnstCodelijst" />
-      <short value="Severity" />
-      <definition value="States the severity of an allergic reaction." />
-      <alias value="AllergieErnst" />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
-      </type>
-      <mapping>
-        <identity value="hcim-allergyintolerance-v1.0.2-2015EN" />
-        <map value="NL-CM:8.2.14" />
-        <comment value="Severity. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/MateVanKritiekZijnCodelijst-to-allergy-intolerance-criticality" />
-      </mapping>
-      <mapping>
-        <identity value="hcim-allergyintolerance-v3.0-2016EN" />
-        <map value="NL-CM:8.2.14" />
-        <comment value="Severity. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/MateVanKritiekZijnCodelijst-to-allergy-intolerance-criticality" />
-      </mapping>
-      <mapping>
-        <identity value="hcim-allergyintolerance-v3.2-2017EN" />
-        <map value="NL-CM:8.2.14" />
-        <comment value="Severity. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/MateVanKritiekZijnCodelijst-to-allergy-intolerance-criticality" />
-      </mapping>
-    </element>
-    <element id="AllergyIntolerance.reaction.severity.extension:ErnstCodelijst.valueCodeableConcept:valueCodeableConcept">
-      <path value="AllergyIntolerance.category.extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
-      <binding>
-        <strength value="extensible" />
-        <description value="ErnstCodelijst" />
-        <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.8.2.6--20171231000000" />
-          <display value="ErnstCodelijst" />
-        </valueSetReference>
-      </binding>
-    </element>
     <element id="AllergyIntolerance.reaction.exposureRoute">
       <path value="AllergyIntolerance.reaction.exposureRoute" />
       <short value="MannerOfExposure" />

--- a/Profiles - ZIB 2017/zib-AllergyIntolerance.xml
+++ b/Profiles - ZIB 2017/zib-AllergyIntolerance.xml
@@ -809,6 +809,55 @@ The HCIM defines certain allergy statuses in the AllergieStatusCodelijst. These 
         <comment value="Severity. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/ErnstCodelijst-to-AllergyIntoleranceSeverity" />
       </mapping>
     </element>
+    <element id="AllergyIntolerance.reaction.severity.extension">
+      <path value="AllergyIntolerance.reaction.severity.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="AllergyIntolerance.reaction.severity.extension:ErnstCodelijst">
+      <path value="AllergyIntolerance.reaction.severity.extension" />
+      <sliceName value="ErnstCodelijst" />
+      <short value="Severity" />
+      <definition value="States the severity of an allergic reaction." />
+      <alias value="AllergieErnst" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+      </type>
+      <mapping>
+        <identity value="hcim-allergyintolerance-v1.0.2-2015EN" />
+        <map value="NL-CM:8.2.14" />
+        <comment value="Severity. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/MateVanKritiekZijnCodelijst-to-allergy-intolerance-criticality" />
+      </mapping>
+      <mapping>
+        <identity value="hcim-allergyintolerance-v3.0-2016EN" />
+        <map value="NL-CM:8.2.14" />
+        <comment value="Severity. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/MateVanKritiekZijnCodelijst-to-allergy-intolerance-criticality" />
+      </mapping>
+      <mapping>
+        <identity value="hcim-allergyintolerance-v3.2-2017EN" />
+        <map value="NL-CM:8.2.14" />
+        <comment value="Severity. See for details the ConceptMap https://simplifier.net/resolve?target=simplifier&amp;canonical=http://nictiz.nl/fhir/ConceptMap/MateVanKritiekZijnCodelijst-to-allergy-intolerance-criticality" />
+      </mapping>
+    </element>
+    <element id="AllergyIntolerance.reaction.severity.extension:ErnstCodelijst.valueCodeableConcept:valueCodeableConcept">
+      <path value="AllergyIntolerance.category.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="ErnstCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.8.2.6--20171231000000" />
+          <display value="ErnstCodelijst" />
+        </valueSetReference>
+      </binding>
+    </element>
     <element id="AllergyIntolerance.reaction.exposureRoute">
       <path value="AllergyIntolerance.reaction.exposureRoute" />
       <short value="MannerOfExposure" />

--- a/Profiles - ZIB 2017/zib-Encounter.xml
+++ b/Profiles - ZIB 2017/zib-Encounter.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="zib-Encounter" />
   <url value="http://nictiz.nl/fhir/StructureDefinition/zib-Encounter" />
-  <version value="2.1.1" />
+  <version value="2.1.2" />
   <name value="Zib Encounter" />
   <title value="HCIM Encounter" />
   <status value="active" />
@@ -95,6 +95,50 @@
       <comment value="A ConceptMap (https://simplifier.net/resolve?canonical=http://nictiz.nl/fhir/ConceptMap/ContactTypeCodelijst-to-ActEncounterCode) is available that maps ContactTypeCodelist to the ActEncounterCode valueset." />
       <alias value="ContactType" />
       <min value="1" />
+      <mapping>
+        <identity value="hcim-encounter-v1.2-2015EN" />
+        <map value="NL-CM:15.1.2" />
+        <comment value="ContactType" />
+      </mapping>
+      <mapping>
+        <identity value="hcim-encounter-v3.0-2016EN" />
+        <map value="NL-CM:15.1.2" />
+        <comment value="ContactType" />
+      </mapping>
+      <mapping>
+        <identity value="hcim-encounter-v3.1-2017EN" />
+        <map value="NL-CM:15.1.2" />
+        <comment value="ContactType" />
+      </mapping>
+    </element>
+    <element id="Encounter.class.extension">
+      <path value="Encounter.class.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Encounter.class.extension:ContactTypeCodelist">
+      <path value="Encounter.class.extension" />
+      <sliceName value="ContactTypeCodelist" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+      </type>
+    </element>
+    <element id="Encounter.class.extension:ContactTypeCodelist.valueCodeableConcept:valueCodeableConcept">
+      <path value="Encounter.class.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="ContactTypeCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.15.1.1--20171231000000" />
+        </valueSetReference>
+      </binding>
       <mapping>
         <identity value="hcim-encounter-v1.2-2015EN" />
         <map value="NL-CM:15.1.2" />

--- a/Profiles - ZIB 2017/zib-Problem.xml
+++ b/Profiles - ZIB 2017/zib-Problem.xml
@@ -108,6 +108,55 @@
         <map value="NL-CM:5.1.4" />
         <comment value="ProblemStatus. The relationship between the HCIM codes and the Resource codes is covered in the ConceptMaps: ProbleemStatusCodelijst-to-Condition-Clinical-Status-Codes and Condition-Clinical-Status-Codes-to-ProbleemStatusCodelijst" />
       </mapping>
+    </element> 
+    <element id="Condition.clinicalStatus.extension">
+      <path value="Condition.clinicalStatus.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Condition.clinicalStatus.extension:ProbleemstatusCodelijst">
+      <path value="Condition.clinicalStatus.extension" />
+      <sliceName value="ProbleemstatusCodelijst" />
+      <short value="clinicalstatus" />
+      <definition value="Describes the condition of the problem, use this extension to include the original ZIB code" />
+      <alias value="Probleemstatus" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+      </type>
+      <mapping>
+        <identity value="hcim-concernfortransfer-v1.2-2015EN" />
+        <map value="NL-CM:5.1.4" />
+        <comment value="ProblemStatus" />
+      </mapping>
+      <mapping>
+        <identity value="hcim-concernfortransfer-v3.0-2016EN" />
+        <map value="NL-CM:5.1.4" />
+        <comment value="ProblemStatus" />
+      </mapping>
+      <mapping>
+        <identity value="hcim-problem-v1.2-2017EN" />
+        <map value="NL-CM:5.1.4" />
+        <comment value="ProblemStatus. The relationship between the HCIM codes and the Resource codes is covered in the ConceptMaps: ProbleemStatusCodelijst-to-Condition-Clinical-Status-Codes and Condition-Clinical-Status-Codes-to-ProbleemStatusCodelijst" />
+      </mapping>
+    </element>
+    <element id="Condition.clinicalStatus.extension:ProbleemstatusCodelijst.valueCodeableConcept:valueCodeableConcept">
+      <path value="Condition.clinicalStatus.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="ProbleemStatusCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.5.1.2--20171231000000" />
+          <display value="ProbleemStatusCodelijst" />
+        </valueSetReference>
+      </binding>
     </element>
     <element id="Condition.verificationStatus">
       <path value="Condition.verificationStatus" />
@@ -120,6 +169,45 @@
         <map value="NL-CM:5.1.10" />
         <comment value="VerificationStatus" />
       </mapping>
+    </element>
+    <element id="Condition.verificationStatus.extension">
+      <path value="Condition.verificationStatus.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Condition.verificationStatus.extension:VerificatieStatusCodelijst">
+      <path value="Condition.verificationStatus.extension" />
+      <sliceName value="VerificatieStatusCodelijst" />
+      <short value="Verificationstatus" />
+      <definition value="Describes the verification status of the problem, use this extension to include the original ZIB code" />
+      <alias value="VerificatieStatusCodelijst" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
+      </type>
+      <mapping>
+        <identity value="hcim-problem-v1.2-2017EN" />
+        <map value="NL-CM:5.1.10" />
+        <comment value="A ConceptMap (https://simplifier.net/resolve?canonical=http://nictiz.nl/fhir/ConceptMap/VerificatieStatusCodelijst-to-ConditionVerificationStatus) is available" />
+      </mapping>
+    </element>
+    <element id="Condition.verificationStatus.extension:VerificatieStatusCodelijst.valueCodeableConcept:valueCodeableConcept">
+      <path value="Condition.verificationStatus.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="VerificatieStatusCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.5.1.4--20171231000000" />
+          <display value="VerificatieStatusCodelijst" />
+        </valueSetReference>
+      </binding>
     </element>
     <element id="Condition.category">
       <path value="Condition.category" />

--- a/Profiles - ZIB 2017/zib-Problem.xml
+++ b/Profiles - ZIB 2017/zib-Problem.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="zib-Problem" />
   <url value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem" />
-  <version value="2.2.0" />
+  <version value="2.2.1" />
   <name value="Zib Problem" />
   <title value="HCIM Problem" />
   <status value="active" />
@@ -108,7 +108,7 @@
         <map value="NL-CM:5.1.4" />
         <comment value="ProblemStatus. The relationship between the HCIM codes and the Resource codes is covered in the ConceptMaps: ProbleemStatusCodelijst-to-Condition-Clinical-Status-Codes and Condition-Clinical-Status-Codes-to-ProbleemStatusCodelijst" />
       </mapping>
-    </element> 
+    </element>
     <element id="Condition.clinicalStatus.extension">
       <path value="Condition.clinicalStatus.extension" />
       <slicing>
@@ -119,17 +119,28 @@
         <rules value="open" />
       </slicing>
     </element>
-    <element id="Condition.clinicalStatus.extension:ProbleemstatusCodelijst">
+    <element id="Condition.clinicalStatus.extension:ProblemStatusCodelist">
       <path value="Condition.clinicalStatus.extension" />
-      <sliceName value="ProbleemstatusCodelijst" />
+      <sliceName value="ProblemStatusCodelist" />
       <short value="clinicalstatus" />
       <definition value="Describes the condition of the problem, use this extension to include the original ZIB code" />
       <alias value="Probleemstatus" />
-      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/code-specification" />
       </type>
+    </element>
+    <element id="Condition.clinicalStatus.extension:ProblemStatusCodelist.valueCodeableConcept:valueCodeableConcept">
+      <path value="Condition.clinicalStatus.extension.valueCodeableConcept" />
+      <sliceName value="valueCodeableConcept" />
+      <binding>
+        <strength value="extensible" />
+        <description value="ProbleemStatusCodelijst" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.5.1.2--20171231000000" />
+          <display value="ProbleemStatusCodelijst" />
+        </valueSetReference>
+      </binding>
       <mapping>
         <identity value="hcim-concernfortransfer-v1.2-2015EN" />
         <map value="NL-CM:5.1.4" />
@@ -145,18 +156,6 @@
         <map value="NL-CM:5.1.4" />
         <comment value="ProblemStatus. The relationship between the HCIM codes and the Resource codes is covered in the ConceptMaps: ProbleemStatusCodelijst-to-Condition-Clinical-Status-Codes and Condition-Clinical-Status-Codes-to-ProbleemStatusCodelijst" />
       </mapping>
-    </element>
-    <element id="Condition.clinicalStatus.extension:ProbleemstatusCodelijst.valueCodeableConcept:valueCodeableConcept">
-      <path value="Condition.clinicalStatus.extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
-      <binding>
-        <strength value="extensible" />
-        <description value="ProbleemStatusCodelijst" />
-        <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.5.1.2--20171231000000" />
-          <display value="ProbleemStatusCodelijst" />
-        </valueSetReference>
-      </binding>
     </element>
     <element id="Condition.verificationStatus">
       <path value="Condition.verificationStatus" />
@@ -274,9 +273,6 @@
       <definition value="Anatomical location which is the focus of the procedure." />
       <alias value="ProbleemAnatomischeLocatie" />
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="BodySite" />
-        </extension>
         <strength value="extensible" />
         <description value="ProbleemAnatomischeLocatieCodelijst" />
         <valueSetReference>


### PR DESCRIPTION
Hoi Pieter,

Hopelijk gaat het alweer wat beter! Ik heb op volgens mij alle mogelijke plekken de code.specificatione extensie toegevoegd. In NL-core-address was dit volgens Alexander niet wenselijk omdat daar al gebruik gemaakt wordt van een specifieke extensie AD_use. Op een aantal andere plekken werd gewoon de codelijst gebruikt die door de ZIB gewenst is, dus snap ik daar het bestaan van de conceptmaps niet helemaal. Misschien dat we daar na de vakantie als je weer fit bent even naar moeten kijken. Als laatste zitten in NL-core-contactpoint nu meerdere code.speciication extensies, misschien dat daar op deze manier wat overlap in zit maar vond dat erg lastig inschatten. 

Fijne feestdagen alvast!
