### PR TITLE
MM-1167: added missing strength in Patient.maritalstatus

### DIFF
--- a/Profiles - ZIB 2017/nl-core-patient.xml
+++ b/Profiles - ZIB 2017/nl-core-patient.xml
@@ -600,6 +600,7 @@
       <definition value="This field contains a patient's most recent marital (civil) status. A person’s marital status according to the terms and definition in the Dutch civil code." />
       <alias value="BurgerlijkeStaat" />
       <binding>
+        <strength value="extensible" />
         <valueSetReference>
           <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.7.9.1--20171231000000" />
           <display value="BurgerlijkeStaatCodelijst" />


### PR DESCRIPTION
A fix for https://bits.nictiz.nl/browse/MM-1167 (based on the `release-1.3.10` branch)