### PR TITLE
MM-1006 Enhance HCIM GeneralMeasurement profile for separate MeasurementResults

### DIFF
--- a/Examples/zib-GeneralMeasurement-01.xml
+++ b/Examples/zib-GeneralMeasurement-01.xml
@@ -4,58 +4,31 @@
     <meta>
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-GeneralMeasurement"/>
     </meta>
-    <text>
-        <status value="generated"/>
-        <div xmlns="http://www.w3.org/1999/xhtml">
-            <table>
-                <caption>Observatie/bepaling. Subject: <a href="Patient/nl-core-patient-03">Irma
-                        Jongeneel-de Haas</a>. Status: definitief</caption>
-                <tfoot>
-                    <tr>
-                        <td colspan="2">Waarschijnlijk delier</td>
-                    </tr>
-                </tfoot>
-                <tbody>
-                    <tr>
-                        <th>Bepalingdatum/tijd</th>
-                        <td>2018-09-10</td>
-                    </tr>
-                    <tr>
-                        <th>Code</th>
-                        <th>Waarde</th>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span
-                                title="Score list delirium (record artifact) (11021000146103 - SNOMED CT)"
-                                >Score list delirium (record artifact)</span>
-                        </td>
-                        <td>7</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </text>
-    <status value="final"/>
-    <!-- MeasurementName -->
+    <!--Resultstatus-->
+    <status value="registered"/>
+    <!--Investigation-->
     <code>
         <coding>
             <system value="http://snomed.info/sct"/>
-            <code value="11021000146103"/>
-            <display value="Score list delirium (record artifact)"/>
+            <code value="273513009"/>
+            <display value="Health of the Nation Outcome Scale (generic version) (assessment scale)"/>
         </coding>
     </code>
     <subject>
         <reference value="Patient/nl-core-patient-03"/>
         <display value="Irma Jongeneel-de Haas"/>
     </subject>
-    <!-- ResultDateTime -->
-    <effectiveDateTime value="2018-09-10"/>
-    <!-- ResultValue -->
-    <valueCodeableConcept>
-        <text value="7"/>
-    </valueCodeableConcept>
-    <!-- Comment -->
-    <comment value="Waarschijnlijk delier"/>
-    <!-- MeasuringMethod -->
+    <!--MeasurementResult-->
+    <related>
+        <target>
+            <reference value="Observation/zib-generalmeasurement-result-01"/>
+            <display value="MeasurementResult - Summated"/>
+        </target>
+    </related>
+    <related>
+        <target>
+            <reference value="Observation/zib-generalmeasurement-result-02"/>
+            <display value="MeasurementResult - Item 1"/>
+        </target>
+    </related>
 </Observation>

--- a/Examples/zib-GeneralMeasurement-Result-01.xml
+++ b/Examples/zib-GeneralMeasurement-Result-01.xml
@@ -1,0 +1,29 @@
+<Observation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhir"
+    xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/observation.xsd">
+    <id value="zib-generalmeasurement-result-01"/>
+    <meta>
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-GeneralMeasurement"/>
+    </meta>
+    <status value="registered"/>
+    <!-- MeasurementName -->
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct"/>
+            <code value="281113000"/>
+            <display value="Health of the Nation Outcome Scale - summated (generic version) (assessment scale)"/>
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/nl-core-patient-03"/>
+        <display value="Irma Jongeneel-de Haas"/>
+    </subject>
+    <!-- ResultDateTime -->
+    <effectiveDateTime value="2018-09-05T12:00:00+01:00"/>
+    <!-- ResultValue -->
+    <valueCodeableConcept>
+        <text value="7"/>
+    </valueCodeableConcept>
+    <!-- Comment -->
+    <comment value="Waarschijnlijk delier"/>
+    <!-- MeasuringMethod -->
+</Observation>

--- a/Examples/zib-GeneralMeasurement-Result-02.xml
+++ b/Examples/zib-GeneralMeasurement-Result-02.xml
@@ -1,0 +1,28 @@
+<Observation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhir"
+    xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/observation.xsd">
+    <id value="zib-generalmeasurement-result-02"/>
+    <meta>
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-GeneralMeasurement"/>
+    </meta>
+    <status value="registered"/>
+    <!-- MeasurementName -->
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct"/>
+            <code value="281115007"/>
+            <display value="Health of the Nation Outcome Scale item 1 - aggressive/disruptive behavior (assessment scale)"/>
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/nl-core-patient-03"/>
+        <display value="Irma Jongeneel-de Haas"/>
+    </subject>
+    <!-- ResultDateTime -->
+    <effectiveDateTime value="2018-09-05T12:10:17+01:00"/>
+    <!-- ResultValue -->
+    <valueCodeableConcept>
+        <text value="2"/>
+    </valueCodeableConcept>
+    <!-- Comment -->
+    <!-- MeasuringMethod -->
+</Observation>

--- a/Profiles - ZIB 2017/zib-GeneralMeasurement.xml
+++ b/Profiles - ZIB 2017/zib-GeneralMeasurement.xml
@@ -97,7 +97,8 @@
     </element>
     <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <definition value="ResultDateTime" />
+      <short value="ResultDateTime" />
+      <definition value="Date and if possible the time at which the entire or specific result measurement was carried out." />
       <alias value="UitslagDatumTijd" />
       <mapping>
         <identity value="hcim-generalmeasurment-v3.0-2017EN" />
@@ -145,18 +146,18 @@
         <comment value="MeasuringMethod" />
       </mapping>
     </element>
+    <element id="Observation.related">
+      <path value="Observation.related" />
+      <short value="MeasurementResult" />
+      <definition value="Container of the MeasurementResult concept. This container contains all data elements of the MeasurementResult concept." />
+      <alias value="MeetUitslag" />
+    </element>
     <element id="Observation.related.target">
       <path value="Observation.related.target" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-GeneralMeasurement" />
       </type>
-    </element>
-    <element id="Observation.component">
-      <path value="Observation.component" />
-      <short value="MeasurementResult" />
-      <definition value="Container of the MeasurementResult concept. This container contains all data elements of the MeasurementResult concept." />
-      <alias value="MeetUitslag" />
     </element>
     <element id="Observation.component.code">
       <path value="Observation.component.code" />
@@ -171,11 +172,6 @@
           <display value="MetingNaamCodelijst" />
         </valueSetReference>
       </binding>
-      <mapping>
-        <identity value="hcim-generalmeasurment-v3.0-2017EN" />
-        <map value="NL-CM:13.3.6" />
-        <comment value="MeasurementName" />
-      </mapping>
     </element>
   </differential>
 </StructureDefinition>

--- a/Profiles - ZIB 2017/zib-GeneralMeasurement.xml
+++ b/Profiles - ZIB 2017/zib-GeneralMeasurement.xml
@@ -70,26 +70,23 @@
         <comment value="ResultStatus" />
       </mapping>
     </element>
-    <element id="Observation.code.coding">
-      <path value="Observation.code.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="$this" />
-        </discriminator>
-        <rules value="closed" />
-      </slicing>
-      <min value="1" />
-    </element>
-    <element id="Observation.code.coding:TestCodelist">
-      <path value="Observation.code.coding" />
-      <sliceName value="TestCodelist" />
-      <short value="Investigation" />
-      <definition value="A general measurement can contain multiple components. This concept contains the name and code of the entire measurement. The components are represented in one or more MeasurementResult concepts." />
+    <element id="Observation.code">
+      <path value="Observation.code" />
+      <code>
+        <system value="http://snomed.info/sct" />
+        <code value="2.16.840.1.113883.6.96" />
+        <display value="SNOMED - All values" />
+      </code>
+      <short value="Investigation or MeasurementName" />
+      <definition value="A general measurement can contain multiple components. This concept contains the name and code of the entire measurement. The components are represented in one or more MeasurementResult concepts. Herby will the description (name and code) of the measurement used." />
       <alias value="Onderzoek" />
-      <max value="1" />
+      <alias value="MetingNaam" />
       <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="ObservationCode" />
+        </extension>
         <strength value="extensible" />
+        <description value="TestCodelist or MeasurementNameCodelist" />
         <valueSetReference>
           <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.3.3--20171231000000" />
         </valueSetReference>
@@ -99,23 +96,10 @@
         <map value="NL-CM:13.3.2" />
         <comment value="Investigation" />
       </mapping>
-    </element>
-    <element id="Observation.code.coding:MeasurementNameCodelist">
-      <path value="Observation.code.coding" />
-      <sliceName value="MeasurementNameCodelist" />
-      <short value="MeasurementName" />
-      <definition value="Description (name and code) of the measurement." />
-      <alias value="MetingNaam" />
-      <max value="1" />
-      <binding>
-        <strength value="extensible" />
-        <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.3.2--20171231000000" />
-        </valueSetReference>
-      </binding>
       <mapping>
         <identity value="hcim-generalmeasurment-v3.0-2017EN" />
         <map value="NL-CM:13.3.6" />
+        <comment value="MeasurementName" />
       </mapping>
     </element>
     <element id="Observation.effective[x]">

--- a/Profiles - ZIB 2017/zib-GeneralMeasurement.xml
+++ b/Profiles - ZIB 2017/zib-GeneralMeasurement.xml
@@ -70,18 +70,28 @@
         <comment value="ResultStatus" />
       </mapping>
     </element>
-    <element id="Observation.code">
-      <path value="Observation.code" />
+    <element id="Observation.code.coding">
+      <path value="Observation.code.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="$this" />
+        </discriminator>
+        <rules value="closed" />
+      </slicing>
+      <min value="1" />
+    </element>
+    <element id="Observation.code.coding:OnderzoekCodelijst">
+      <path value="Observation.code.coding" />
+      <sliceName value="OnderzoekCodelijst" />
       <short value="Investigation | MeasurementName" />
       <definition value="A general measurement can contain multiple components. This concept contains the name and code of the entire measurement." />
       <alias value="Onderzoek" />
-      <alias value="MetingNaam" />
       <binding>
         <strength value="extensible" />
         <description value="SNOMED CT all concepts" />
         <valueSetReference>
           <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.3.3--20171231000000" />
-          <display value="OnderzoekCodelijst" />
         </valueSetReference>
       </binding>
       <mapping>
@@ -89,10 +99,23 @@
         <map value="NL-CM:13.3.2" />
         <comment value="Investigation" />
       </mapping>
+    </element>
+    <element id="Observation.code.coding:sliceCoding">
+      <path value="Observation.code.coding" />
+      <sliceName value="sliceCoding" />
+      <short value="MeasurementName" />
+      <definition value="Description (name and code) of the measurement." />
+      <alias value="MetingNaam" />
+      <binding>
+        <strength value="extensible" />
+        <description value="SNOMED CT - all values" />
+        <valueSetReference>
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.3.2--20171231000000" />
+        </valueSetReference>
+      </binding>
       <mapping>
         <identity value="hcim-generalmeasurment-v3.0-2017EN" />
         <map value="NL-CM:13.3.6" />
-        <comment value="MeasurementName" />
       </mapping>
     </element>
     <element id="Observation.effective[x]">
@@ -158,20 +181,6 @@
         <code value="Reference" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-GeneralMeasurement" />
       </type>
-    </element>
-    <element id="Observation.component.code">
-      <path value="Observation.component.code" />
-      <short value="MeasurementName" />
-      <definition value="Description (name and code) of the measurement." />
-      <alias value="MetingNaam" />
-      <binding>
-        <strength value="extensible" />
-        <description value="SNOMED CT - all values" />
-        <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.3.2--20171231000000" />
-          <display value="MetingNaamCodelijst" />
-        </valueSetReference>
-      </binding>
     </element>
   </differential>
 </StructureDefinition>

--- a/Profiles - ZIB 2017/zib-GeneralMeasurement.xml
+++ b/Profiles - ZIB 2017/zib-GeneralMeasurement.xml
@@ -81,15 +81,15 @@
       </slicing>
       <min value="1" />
     </element>
-    <element id="Observation.code.coding:OnderzoekCodelijst">
+    <element id="Observation.code.coding:TestCodelist">
       <path value="Observation.code.coding" />
-      <sliceName value="OnderzoekCodelijst" />
-      <short value="Investigation | MeasurementName" />
-      <definition value="A general measurement can contain multiple components. This concept contains the name and code of the entire measurement." />
+      <sliceName value="TestCodelist" />
+      <short value="Investigation" />
+      <definition value="A general measurement can contain multiple components. This concept contains the name and code of the entire measurement. The components are represented in one or more MeasurementResult concepts." />
       <alias value="Onderzoek" />
+      <max value="1" />
       <binding>
         <strength value="extensible" />
-        <description value="SNOMED CT all concepts" />
         <valueSetReference>
           <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.3.3--20171231000000" />
         </valueSetReference>
@@ -100,15 +100,15 @@
         <comment value="Investigation" />
       </mapping>
     </element>
-    <element id="Observation.code.coding:sliceCoding">
+    <element id="Observation.code.coding:MeasurementNameCodelist">
       <path value="Observation.code.coding" />
-      <sliceName value="sliceCoding" />
+      <sliceName value="MeasurementNameCodelist" />
       <short value="MeasurementName" />
       <definition value="Description (name and code) of the measurement." />
       <alias value="MetingNaam" />
+      <max value="1" />
       <binding>
         <strength value="extensible" />
-        <description value="SNOMED CT - all values" />
         <valueSetReference>
           <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.3.2--20171231000000" />
         </valueSetReference>


### PR DESCRIPTION
1. Er is een hoofd Observatie waar het algemene onderzoek onder valt;
2. Related wordt toegevoegd aan het profiel;
3. Component wordt verwijderd uit het profiel;
4. Elke Meetuitslag wordt gekoppeld aan de hoofd Observatie door middel van Related.
Ik heb dit aangepast in ZIB-GeneralMeasurement met de vorige feedback. 

Verder heb ik twee examples gemaakt (GeneralMeasurementResult) en zib-GeneralMeasurement example aangepast.