### PR TITLE
Mm 1006

### DIFF
--- a/Examples/zib-GeneralMeasurement-01.xml
+++ b/Examples/zib-GeneralMeasurement-01.xml
@@ -19,7 +19,7 @@
     <related>
         <target>
             <reference value="Observation/zib-generalmeasurement-result-01"/>
-            <display value="MeasurementResult - Health of the Nation Outcome Scale - summated (generic version) "/>
+            <display value="MeasurementResult - Health of the Nation Outcome Scale - summated (generic version)"/>
         </target>
     </related>
     <related>

--- a/Profiles - ZIB 2017/Valuesets/ResultaatStatusCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.13.3.1--20171231000000.xml
+++ b/Profiles - ZIB 2017/Valuesets/ResultaatStatusCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.13.3.1--20171231000000.xml
@@ -1,0 +1,106 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.13.3.1--20171231000000"/>
+    <meta>
+        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/3.0/StructureDefinition/ValueSet"/>-->
+    </meta>
+    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+        <valuePeriod>
+            <start value="2017-12-31T00:00:00+02:00"/>
+        </valuePeriod>
+    </extension>
+    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.3.1--20171231000000"/>
+    <identifier>
+        <use value="official"/>
+        <system value="http://art-decor.org/ns/oids/vs"/>
+        <value value="2.16.840.1.113883.2.4.3.11.60.40.2.13.3.1"/>
+    </identifier>
+    <version value="2017-12-31T00:00:00"/>
+    <name value="ResultaatStatusCodelijst"/>
+    <title value="ResultaatStatusCodelijst"/>
+    <status value="active"/>
+    <experimental value="false"/>
+    <publisher value="Registratie aan de bron"/>
+    <contact>
+        <name value="Registratie aan de bron"/>
+        <telecom>
+            <system value="url"/>
+            <value value="https://www.registratieaandebron.nl"/>
+        </telecom>
+        <telecom>
+            <system value="url"/>
+            <value value="https://zibs.nl"/>
+        </telecom>
+    </contact>
+    <description value="ResultaatStatusCodelijst"/>
+    <immutable value="false"/>
+    <compose>
+        <include>
+            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.15.1"/>
+            <concept>
+                <code value="pending"/>
+                <display value="Pending"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Uitslag volgt"/>
+                </designation>
+            </concept>
+            <concept>
+                <code value="preliminary"/>
+                <display value="Preliminary"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Voorlopig"/>
+                </designation>
+            </concept>
+            <concept>
+                <code value="final"/>
+                <display value="Final"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Definitief"/>
+                </designation>
+            </concept>
+            <concept>
+                <code value="appended"/>
+                <display value="Appended"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Aanvullend"/>
+                </designation>
+            </concept>
+            <concept>
+                <code value="corrected"/>
+                <display value="Corrected"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Gecorrigeerd"/>
+                </designation>
+            </concept>
+        </include>
+    </compose>
+</ValueSet>


### PR DESCRIPTION
Comment (from Ardon) copied from other Pull Request:

Hi @eduardderijcke ,
Good work. Here my review that perhaps goes broader than the original fix:

1. - [x] The examples have a Observation.status = registered. This is not correct as this status means "The existence of the observation is registered, but there is no result yet available.' - while the result is available. This brought my attention to this element: the zib ResultStatus is mapped to .status. However, the bound valuesets do not completely match. I can't find a ConceptMap nor a code-specification extension.
2. - [x] In the examples a .valueCodeableConcept.text is used for string concepts. I would rather use a valueString than, or a Quantity for the score. Perhaps have a look at international examples how they do it.
3. - [x] The Observation.related still doesn't contain proper implementation guidance. In the element.definition, it notes that it is the container.... ect.
4. - [x] Please provide enough guidance that this profile is used for the parent and children observations.
5. - [x] Observation.code has an incorrect element.code. Why is this added? This isn't necessary and the current code is also not correct.
6. - [x] Observation.code : I would expect a little more documentation in the .comment for example about that one of the two valueset has been bound but that both valueset contains the same Snomed codes.
7. - [x] Observation.code: missing a valuesetReference.display
