### PR TITLE
MM-1703: changed .short value in nl-core-address profile to align wit…

### DIFF
--- a/Profiles - ZIB 2017/nl-core-address.xml
+++ b/Profiles - ZIB 2017/nl-core-address.xml
@@ -591,8 +591,8 @@ If Address.type is &quot;both&quot; then this is to be understood as a dual purp
     </element>
     <element id="Address.country">
       <path value="Address.country" />
-      <short value="Country (can be ISO 3166 3 letter code)" />
       <definition value="A country (code) for the address." />
+      <short value="Country (e.g. can be ISO 3166 2 or 3 letter code)" />
       <comment value="The FHIR datatype does not properly support coding the country using a CodeableConcept or Coding datatype. If the sender supports coded countries, it SHALL send the coded value using the code-specification extension under Address.country." />
       <alias value="land" />
       <example>

--- a/Profiles - ZIB 2017/nl-core-address.xml
+++ b/Profiles - ZIB 2017/nl-core-address.xml
@@ -591,10 +591,10 @@ If Address.type is &quot;both&quot; then this is to be understood as a dual purp
     </element>
     <element id="Address.country">
       <path value="Address.country" />
-      <definition value="A country (code) for the address." />
-      <short value="Country (e.g. can be ISO 3166 2 or 3 letter code)" />
+      <short value="Country" />
+      <definition value="Country in which the address is located." />
       <comment value="The FHIR datatype does not properly support coding the country using a CodeableConcept or Coding datatype. If the sender supports coded countries, it SHALL send the coded value using the code-specification extension under Address.country." />
-      <alias value="land" />
+      <alias value="Land" />
       <example>
         <label value="Example country" />
         <valueString value="NLD" />


### PR DESCRIPTION
…h the STU3 spec

@ArdonToonstra wil je dit nalopen? Ik heb alleen de .short overgenomen uit STU3. Enkele gedachten: de zib schrijft zowel een GBA codelijst (4 cijferige codes) als een ISO-codelijst (2 letterige codes) voor, waarbij je de code-specification extensie kunt gebruiken voor die eerstgenoemde. 
Daarbij, de zib spreekt geen voorkeur uit voor welke je gebruikt. We zouden een uitleg kunnen toevoegen dat je in principe de ISO-code meegeeft in de string en daarbij nog de extensie gebruikt?
@Stephanfur0re FYI