### PR TITLE
MM-2056: Updated and unified 2017 HCIM references

### DIFF
--- a/Profiles - ZIB 2017/nl-core-address.xml
+++ b/Profiles - ZIB 2017/nl-core-address.xml
@@ -33,7 +33,7 @@
   <mapping>
     <identity value="hcim-addressinformation-v1.0-2017EN" />
     <uri value="https://zibs.nl/wiki/AddressInformation-v1.0(2017EN)" />
-    <name value="HCIM AddressInformation-v1.0.1(2017EN)" />
+    <name value="HCIM AddressInformation-v1.0(2017EN)" />
   </mapping>
   <mapping>
     <identity value="BRP" />

--- a/Profiles - ZIB 2017/nl-core-contactpoint.xml
+++ b/Profiles - ZIB 2017/nl-core-contactpoint.xml
@@ -33,7 +33,7 @@
   <mapping>
     <identity value="hcim-contactinformation-v1.0-2017EN" />
     <uri value="https://zibs.nl/wiki/ContactInformation-v1.0(2017EN)" />
-    <name value="HCIM ContactInformation-v1.0.1(2017EN)" />
+    <name value="HCIM ContactInformation-v1.0(2017EN)" />
   </mapping>
   <kind value="complex-type" />
   <abstract value="false" />

--- a/Profiles - ZIB 2017/nl-core-location.xml
+++ b/Profiles - ZIB 2017/nl-core-location.xml
@@ -35,14 +35,14 @@
     <name value="HCIM ContactInformation-v1.0(2017EN)" />
   </mapping>
   <mapping>
-    <identity value="hcim-addressinformation-v3.1-2017EN" />
+    <identity value="hcim-addressinformation-v1.0-2017EN" />
     <uri value="https://zibs.nl/wiki/AddressInformation-v1.0(2017EN)" />
     <name value="HCIM AddressInformation-v1.0(2017EN)" />
   </mapping>
   <mapping>
-    <identity value="hcim-dispense-v1.0-2017EN" />
-    <uri value="https://zibs.nl/wiki/Dispense-v1.0(2017EN)" />
-    <name value="HCIM Dispense-v1.0(2017EN)" />
+    <identity value="hcim-medicationdispense-v2.0-2017EN" />
+    <uri value="https://zibs.nl/wiki/MedicationDispense-v2.0(2017EN)" />
+    <name value="HCIM MedicationDispense-v2.0(2017EN)" />
   </mapping>
   <mapping>
     <identity value="hcim-healthcareprovider-v3.1.1-2017EN" />
@@ -63,7 +63,7 @@
       <alias value="DispenseLocation" />
       <alias value="Afleverlocatie" />
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.20925" />
         <comment value="DispenseLocation" />
       </mapping>
@@ -121,7 +121,7 @@
         <comment value="AddressInformation" />
       </mapping>
       <mapping>
-        <identity value="hcim-addressinformation-v3.1-2017EN" />
+        <identity value="hcim-addressinformation-v1.0-2017EN" />
         <map value="NL-CM:20.5.1" />
         <comment value="AddressInformation" />
       </mapping>

--- a/Profiles - ZIB 2017/nl-core-patient.xml
+++ b/Profiles - ZIB 2017/nl-core-patient.xml
@@ -104,14 +104,14 @@
     <name value="HCIM ContactPerson-v3.1(2017EN)" />
   </mapping>
   <mapping>
-    <identity value="hcim-healthcareprovider-v3.1-2017EN" />
-    <uri value="https://zibs.nl/wiki/HealthcareProvider-v3.1(2017EN)" />
-    <name value="HCIM HealthcareProvider-v3.1(2017EN)" />
+    <identity value="hcim-healthcareprovider-v3.1.1-2017EN" />
+    <uri value="https://zibs.nl/wiki/HealthcareProvider-v3.1.1(2017EN)" />
+    <name value="HCIM HealthcareProvider-v3.1.1(2017EN)" />
   </mapping>
   <mapping>
-    <identity value="hcim-healthprofessional-v3.1-2017EN" />
-    <uri value="https://zibs.nl/wiki/HealthProfessional-v3.1(2017EN)" />
-    <name value="HCIM HealthProfessional-v3.1(2017EN)" />
+    <identity value="hcim-healthprofessional-v3.2-2017EN" />
+    <uri value="https://zibs.nl/wiki/HealthProfessional-v3.2(2017EN)" />
+    <name value="HCIM HealthProfessional-v3.2(2017EN)" />
   </mapping>
   <mapping>
     <identity value="hcim-nationality-v3.0-2017EN" />
@@ -161,7 +161,7 @@
     <name value="HCIM FamilySituation-v3.0(2017EN)" />
   </mapping>
   <mapping>
-    <identity value="hcim-LifeStance-v3.1-2017EN" />
+    <identity value="hcim-lifestance-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/LifeStance-v3.1(2017EN)" />
     <name value="HCIM LifeStance-v3.1(2017EN)" />
   </mapping>
@@ -338,7 +338,7 @@
       <path value="Patient.extension.valueCodeableConcept" />
       <sliceName value="valueCodeableConcept" />
       <mapping>
-        <identity value="hcim-LifeStance-v3.1-2017EN" />
+        <identity value="hcim-lifestance-v3.1-2017EN" />
         <map value="NL-CM:7.5.2" />
         <comment value="LifeStance" />
       </mapping>
@@ -996,7 +996,7 @@
         <comment value="HealthcareProvider" />
       </mapping>
       <mapping>
-        <identity value="hcim-healthcareprovider-v3.1-2017EN" />
+        <identity value="hcim-healthcareprovider-v3.1.1-2017EN" />
         <map value="NL-CM:17.2.1" />
         <comment value="HealthcareProvider" />
       </mapping>
@@ -1011,7 +1011,7 @@
         <comment value="HealthProfessional" />
       </mapping>
       <mapping>
-        <identity value="hcim-healthprofessional-v3.1-2017EN" />
+        <identity value="hcim-healthprofessional-v3.2-2017EN" />
         <map value="NL-CM:17.1.1" />
         <comment value="HealthProfessional" />
       </mapping>

--- a/Profiles - ZIB 2017/nl-core-person.xml
+++ b/Profiles - ZIB 2017/nl-core-person.xml
@@ -83,9 +83,9 @@
     <name value="HCIM ContactPerson-v3.1(2017EN)" />
   </mapping>
   <mapping>
-    <identity value="hcim-healthprofessional-v3.1-2017EN" />
-    <uri value="https://zibs.nl/wiki/HealthProfessional-v3.1(2017EN)" />
-    <name value="HCIM HealthProfessional-v3.1(2017EN)" />
+    <identity value="hcim-healthprofessional-v3.2-2017EN" />
+    <uri value="https://zibs.nl/wiki/HealthProfessional-v3.2(2017EN)" />
+    <name value="HCIM HealthProfessional-v3.2(2017EN)" />
   </mapping>
   <mapping>
     <identity value="hcim-payer-v3.1-2017EN" />
@@ -93,9 +93,9 @@
     <name value="HCIM Payer-v3.1(2017EN)" />
   </mapping>
   <mapping>
-    <identity value="hcim-contactinformation-v3.1-2017EN" />
+    <identity value="hcim-contactinformation-v1.0-2017EN" />
     <uri value="https://zibs.nl/wiki/ContactInformation-v1.0(2017EN)" />
-    <name value="HCIM ContactInformation-v3.1(2017EN)" />
+    <name value="HCIM ContactInformation-v1.0(2017EN)" />
   </mapping>
   <kind value="resource" />
   <abstract value="false" />
@@ -217,7 +217,7 @@
         <comment value="HealthcareProviderName" />
       </mapping>
       <mapping>
-        <identity value="hcim-healthprofessional-v3.1-2017EN" />
+        <identity value="hcim-healthprofessional-v3.2-2017EN" />
         <map value="NL-CM:17.1.3" />
         <comment value="NameInformation" />
       </mapping>
@@ -286,7 +286,7 @@
         <comment value="TelephoneE-mail" />
       </mapping>
       <mapping>
-        <identity value="hcim-healthprofessional-v3.1-2017EN" />
+        <identity value="hcim-healthprofessional-v3.2-2017EN" />
         <map value="NL-CM:17.1.8" />
         <comment value="ContactInformation" />
       </mapping>
@@ -306,12 +306,12 @@
         <comment value="ContactInformation" />
       </mapping>
       <mapping>
-        <identity value="hcim-contactinformation-v3.1-2017EN" />
+        <identity value="hcim-contactinformation-v1.0-2017EN" />
         <map value="NL-CM:20.6.2" />
         <comment value="TelephoneNumbers" />
       </mapping>
       <mapping>
-        <identity value="hcim-contactinformation-v3.1-2017EN" />
+        <identity value="hcim-contactinformation-v1.0-2017EN" />
         <map value="NL-CM:20.6.3" />
         <comment value="EmailAddresses" />
       </mapping>
@@ -405,7 +405,7 @@
         <comment value="Address" />
       </mapping>
       <mapping>
-        <identity value="hcim-healthprofessional-v3.1-2017EN" />
+        <identity value="hcim-healthprofessional-v3.2-2017EN" />
         <map value="NL-CM:17.1.7" />
         <comment value="AddressInformation" />
       </mapping>

--- a/Profiles - ZIB 2017/period-duration.xml
+++ b/Profiles - ZIB 2017/period-duration.xml
@@ -18,9 +18,9 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="hcim-timeinterval-v1.0.0-2017EN" />
+    <identity value="hcim-timeinterval-v1.0-2017EN" />
     <uri value="https://zibs.nl/wiki/TimeInterval-v1.0(2017EN)" />
-    <name value="HCIM TimeInterval-v1.0.0(2017EN)" />
+    <name value="HCIM TimeInterval-v1.0(2017EN)" />
   </mapping>
   <kind value="primitive-type" />
   <abstract value="false" />
@@ -43,7 +43,7 @@
         <code value="Duration" />
       </type>
       <mapping>
-        <identity value="hcim-timeinterval-v1.0.0-2017EN" />
+        <identity value="hcim-timeinterval-v1.0-2017EN" />
         <map value="NL-CM:20.3.4" />
         <comment value="Duration" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-AbilityToPerformMouthcareActivities-MedicalDeviceProduct.xml
+++ b/Profiles - ZIB 2017/zib-AbilityToPerformMouthcareActivities-MedicalDeviceProduct.xml
@@ -19,7 +19,7 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="hcim-abilitytoperformmouthcareactivities-v1.0-2017EN" />
+    <identity value="hcim-abilitytoperformmouthcareactivities-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/AbilityToPerformMouthcareActivities-v3.1(2017EN)" />
     <name value="HCIM AbilityToPerformMouthcareActivities-v3.1(2017EN)" />
   </mapping>

--- a/Profiles - ZIB 2017/zib-AbilityToPerformMouthcareActivities.xml
+++ b/Profiles - ZIB 2017/zib-AbilityToPerformMouthcareActivities.xml
@@ -19,7 +19,7 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="hcim-abilitytoperformmouthcareactivities-v1.0-2017EN" />
+    <identity value="hcim-abilitytoperformmouthcareactivities-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/AbilityToPerformMouthcareActivities-v3.1(2017EN)" />
     <name value="HCIM AbilityToPerformMouthcareActivities-v3.1(2017EN)" />
   </mapping>
@@ -33,7 +33,7 @@
       <path value="Observation" />
       <alias value="VermogenTotMondverzorging" />
       <mapping>
-        <identity value="hcim-abilitytoperformmouthcareactivities-v1.0-2017EN" />
+        <identity value="hcim-abilitytoperformmouthcareactivities-v3.1-2017EN" />
         <map value="NL-CM:4.13.1" />
         <comment value="AbilityToPerformMouthcareActivities" />
       </mapping>
@@ -90,7 +90,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-abilitytoperformmouthcareactivities-v1.0-2017EN" />
+        <identity value="hcim-abilitytoperformmouthcareactivities-v3.1-2017EN" />
         <map value="NL-CM:4.13.2" />
         <comment value="DentalHygiene" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-AdministrationAgreement.xml
+++ b/Profiles - ZIB 2017/zib-AdministrationAgreement.xml
@@ -19,9 +19,9 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="hcim-administrationagreement-v1.0-2017EN" />
-    <uri value="https://zibs.nl/wiki/AdministrationAgreement-v1.0(2017EN)" />
-    <name value="HCIM AdministrationAgreement-v1.0(2017EN)" />
+    <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
+    <uri value="https://zibs.nl/wiki/AdministrationAgreement-v1.0.1(2017EN)" />
+    <name value="HCIM AdministrationAgreement-v1.0.1(2017EN)" />
   </mapping>
   <mapping>
     <identity value="Medication-Process-v09" />
@@ -30,9 +30,9 @@
     <comment value="Language of Medication Process is Dutch." />
   </mapping>
   <mapping>
-    <identity value="hcim-instructionsforuse-v1.0-2017EN" />
-    <uri value="https://zibs.nl/wiki/InstructionsForUse-v1.0(2017EN)" />
-    <name value="HCIM InstructionsForUse-v1.0(2017EN)" />
+    <identity value="hcim-instructionsforuse-v1.1-2017EN" />
+    <uri value="https://zibs.nl/wiki/InstructionsForUse-v1.1(2017EN)" />
+    <name value="HCIM InstructionsForUse-v1.1(2017EN)" />
   </mapping>
   <mapping>
     <identity value="hcim-basicelements-v1.0-2017EN" />
@@ -51,7 +51,7 @@
       <definition value="An administration agreement is the use (or administering) instructions from the pharmacist to the patient (or their representative or administrator), whereby a medication agreement is structured at a concrete level." />
       <alias value="Toedieningsafspraak" />
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.20132" />
         <comment value="AdministrationAgreement" />
       </mapping>
@@ -78,7 +78,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-AdministrationAgreement-AuthoredOn" />
       </type>
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.20133" />
         <comment value="AdministrationAgreementDateTime" />
       </mapping>
@@ -95,7 +95,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-AdministrationAgreement-AgreementReason" />
       </type>
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.22499" />
         <comment value="AgreementReason" />
       </mapping>
@@ -110,7 +110,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Medication-PeriodOfUse" />
       </type>
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.22660" />
         <comment value="Maps to the &quot;start date&quot; and &quot;end date&quot; portion of the &quot;PeriodOfUse&quot; element" />
       </mapping>
@@ -127,7 +127,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-MedicationUse-Duration" />
       </type>
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.22660" />
         <comment value="Maps to the &quot;duration&quot; portion of the &quot;PeriodOfUse&quot; element" />
       </mapping>
@@ -144,7 +144,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Medication-AdditionalInformation" />
       </type>
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.23284" />
         <comment value="AdministrationAgreementAdditionalInformation" />
       </mapping>
@@ -209,7 +209,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Medication-StopType" />
       </type>
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.22498" />
         <comment value="AdministrationAgreementStopType" />
       </mapping>
@@ -233,7 +233,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Medication-RepeatPeriodCyclicalSchedule" />
       </type>
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.22505" />
         <comment value="RepeatPeriodCyclicalSchedule" />
       </mapping>
@@ -252,7 +252,7 @@
       <definition value="In the event of an error correction, the value of this element shall be 'entered-in-error'." />
       <alias value="GeannuleerdIndicator" />
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.23034" />
         <comment value="CanceledIndicator. Use status code entered-in-error when CanceledIndicator = true." />
       </mapping>
@@ -306,7 +306,7 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Product" />
       </type>
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.20237" />
         <comment value="MedicineForAdministrationAgreement" />
       </mapping>
@@ -344,7 +344,7 @@
       <definition value="The supplier (pharmacist) that entered the administration agreement." />
       <alias value="Verstrekker" />
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.22097" />
         <comment value="Supplier" />
       </mapping>
@@ -414,7 +414,7 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-MedicationAgreement" />
       </type>
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.22394" />
         <comment value="MedicationAgreement" />
       </mapping>
@@ -425,7 +425,7 @@
       <definition value="Comments on the administration agreement." />
       <alias value="Toelichting" />
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.22275" />
         <comment value="Comment" />
       </mapping>
@@ -437,7 +437,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-InstructionsForUse" />
       </type>
       <mapping>
-        <identity value="hcim-administrationagreement-v1.0-2017EN" />
+        <identity value="hcim-administrationagreement-v1.0.1-2017EN" />
         <map value="NL-CM:9.8.22098" />
         <comment value="InstructionsForUse" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-AdministrationSchedule.xml
+++ b/Profiles - ZIB 2017/zib-AdministrationSchedule.xml
@@ -19,14 +19,14 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="hcim-instructionsforuse-v1.0-2017EN" />
-    <uri value="https://zibs.nl/wiki/InstructionsForUse-v1.0(2017EN)" />
-    <name value="HCIM InstructionsForUse-v1.0(2017EN)" />
+    <identity value="hcim-instructionsforuse-v1.1-2017EN" />
+    <uri value="https://zibs.nl/wiki/InstructionsForUse-v1.1(2017EN)" />
+    <name value="HCIM InstructionsForUse-v1.1(2017EN)" />
   </mapping>
   <mapping>
     <identity value="hcim-range-v1.0-2017EN" />
     <uri value="https://zibs.nl/wiki/Range-v1.0(2017EN)" />
-    <name value="HCIM Part Range-v1.0(2017EN)" />
+    <name value="HCIM Range-v1.0(2017EN)" />
   </mapping>
   <kind value="primitive-type" />
   <abstract value="false" />
@@ -40,7 +40,7 @@
       <definition value="Specifications of the times at which the medication is to be administered. This is indicated as follows: &#xD;&#xA;Time(s) (16:00) or indications (“before meals”) at which the medication is to be taken each day.&#xD;&#xA;A specific number of times the medication is to be taken each day (&quot;3x a day&quot;), indicated with the frequency&#xD;&#xA;A time interval between consecutive doses (“Every 2 hours”, “every 3 days”), indicated with the word Interval.&#xD;&#xA;Combined periods with an interval and duration (“1 daily for three out of four weeks: the pill schedule”)&#xD;&#xA;&#xD;&#xA;If a certain medication is not to be taken daily, the aforementioned can be combined with daily indications: &#xD;&#xA;One or more week days on which the medication is to be administered (e.g. “Monday, Wednesday, Friday”)&#xD;&#xA;”3x a week”, “2x a month”.&#xD;&#xA;&#xD;&#xA;The specified administration “infinite” is automatically to be repeated until: &#xD;&#xA;The end date and time has been reached&#xD;&#xA;The total administration duration has been reached (14 days)&#xD;&#xA;&#xD;&#xA;A specific amount of administrations has been reached (“20 doses”, “one-time only”), to be entered in the NumberOfDoses concept." />
       <alias value="Toedieningsschema" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19948" />
         <comment value="AdministeringSchedule" />
       </mapping>
@@ -51,7 +51,7 @@
       <definition value="The intended time duration for these dosing instructions." />
       <alias value="Doseerduur" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.22506" />
         <comment value="DoseDuration" />
       </mapping>
@@ -62,7 +62,7 @@
       <definition value="Defines the amount of time during which medication is being administered. This is used especially in the context of administering liquids." />
       <alias value="Toedieninsgduur" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.23141" />
         <comment value="DurationOfAdministration" />
       </mapping>
@@ -73,7 +73,7 @@
       <definition value="Defines the unit for the amount of time during which medication is being administered. This is used especially in the context of administering liquids." />
       <alias value="Toedieninsgduur" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.23141" />
         <comment value="DurationOfAdministration" />
       </mapping>
@@ -86,7 +86,7 @@
       <alias value="frequentie vaste waarde" />
       <alias value="frequentie min" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19949" />
         <comment value="Frequency" />
       </mapping>
@@ -120,12 +120,12 @@
       <alias value="Interval" />
       <alias value="Frequentie" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19949" />
         <comment value="Frequency. When frequency is used, set &quot;exact&quot; to false" />
       </mapping>
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19950" />
         <comment value="Interval. When interval is used, set &quot;exact&quot; to true" />
       </mapping>
@@ -137,12 +137,12 @@
       <alias value="Interval" />
       <alias value="Frequentie" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19949" />
         <comment value="Frequency. When frequency is used, set &quot;exact&quot; to false" />
       </mapping>
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19950" />
         <comment value="Interval. When interval is used, set &quot;exact&quot; to true" />
       </mapping>
@@ -162,11 +162,11 @@
               <display value="WeekdagCodelijst-to-days-of-week" />
             </valueReference>
           </extension>
-          <reference value="http://hl7.org/fhir/ValueSet/days-of-week"/>
+          <reference value="http://hl7.org/fhir/ValueSet/days-of-week" />
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19952" />
         <comment value="WeekDay.See for details ConceptMap (http://nictiz.nl/fhir/ConceptMap/WeekdagCodelijst-to-days-of-week)" />
       </mapping>
@@ -177,7 +177,7 @@
       <definition value="The time of administration is a specific time of day (on the clock). This time usually isn’t (intended to be) exact. There can be multiple administering times in one day. The ideal time of administration can also be entered as a time of day (morning, afternoon, evening, night-time). The administration time is then to be left empty, and the time of day can be entered in the TimeOfDay concept." />
       <alias value="Toedientijd" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19951" />
         <comment value="AdministrationTime" />
       </mapping>
@@ -196,11 +196,11 @@
               <display value="DagdeelCodelijst-to-EventTiming" />
             </valueReference>
           </extension>
-          <reference value="http://hl7.org/fhir/ValueSet/event-timing"/>
+          <reference value="http://hl7.org/fhir/ValueSet/event-timing" />
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19953" />
         <comment value="TimeOfDay. See for details the ConceptMap (http://nictiz.nl/fhir/ConceptMap/DagdeelCodelijst-to-EventTiming)" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-ChecklistPainBehaviour.xml
+++ b/Profiles - ZIB 2017/zib-ChecklistPainBehaviour.xml
@@ -19,7 +19,7 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="zib-checklistpainbehavior-v1.0-2017EN" />
+    <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
     <uri value="https://zibs.nl/wiki/ChecklistPainBehavior-v1.0(2017EN)" />
     <name value="HCIM ChecklistPainBehavior-v1.0(2017EN)" />
   </mapping>
@@ -34,7 +34,7 @@
       <short value="ChecklistPainBehaviour" />
       <alias value="ChecklistPijnGedrag" />
       <mapping>
-        <identity value="zib-checklistpainbehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.1" />
         <comment value="ChecklistPainBehaviour" />
       </mapping>
@@ -84,7 +84,7 @@
         <code value="dateTime" />
       </type>
       <mapping>
-        <identity value="ChecklistPainBehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.13" />
         <comment value="ScoreDateTime" />
       </mapping>
@@ -105,7 +105,7 @@
         <value value="10" />
       </maxValueQuantity>
       <mapping>
-        <identity value="ChecklistPainBehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.2" />
         <comment value="TotalScore" />
       </mapping>
@@ -115,7 +115,7 @@
       <short value="Comment" />
       <alias value="Toelichting" />
       <mapping>
-        <identity value="ChecklistPainBehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.14" />
         <comment value="Comment" />
       </mapping>
@@ -161,7 +161,7 @@
         <code value="Quantity" />
       </type>
       <mapping>
-        <identity value="zib-checklistpainbehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.3" />
         <comment value="Face" />
       </mapping>
@@ -202,7 +202,7 @@
         <code value="Quantity" />
       </type>
       <mapping>
-        <identity value="zib-checklistpainbehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.4" />
         <comment value="Mouth" />
       </mapping>
@@ -243,7 +243,7 @@
         <code value="Quantity" />
       </type>
       <mapping>
-        <identity value="zib-checklistpainbehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.5" />
         <comment value="Grimace" />
       </mapping>
@@ -284,7 +284,7 @@
         <code value="Quantity" />
       </type>
       <mapping>
-        <identity value="zib-checklistpainbehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.6" />
         <comment value="LookingSad" />
       </mapping>
@@ -325,7 +325,7 @@
         <code value="Quantity" />
       </type>
       <mapping>
-        <identity value="zib-checklistpainbehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.7" />
         <comment value="Eyes" />
       </mapping>
@@ -366,7 +366,7 @@
         <code value="Quantity" />
       </type>
       <mapping>
-        <identity value="zib-checklistpainbehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.8" />
         <comment value="Panic" />
       </mapping>
@@ -407,7 +407,7 @@
         <code value="Quantity" />
       </type>
       <mapping>
-        <identity value="ChecklistPainBehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.9" />
         <comment value="Moaning" />
       </mapping>
@@ -448,7 +448,7 @@
         <code value="Quantity" />
       </type>
       <mapping>
-        <identity value="zib-checklistpainbehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.10" />
         <comment value="Cry" />
       </mapping>
@@ -489,7 +489,7 @@
         <code value="Quantity" />
       </type>
       <mapping>
-        <identity value="zib-checklistpainbehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.11" />
         <comment value="SoundsOfRestlessness" />
       </mapping>
@@ -530,7 +530,7 @@
         <code value="Quantity" />
       </type>
       <mapping>
-        <identity value="zib-checklistpainbehavior-v1.0-2017EN" />
+        <identity value="hcim-checklistpainbehavior-v1.0-2017EN" />
         <map value="NL-CM:12.17.12" />
         <comment value="Tears" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-DevelopmentChild.xml
+++ b/Profiles - ZIB 2017/zib-DevelopmentChild.xml
@@ -19,7 +19,7 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="DevelopmentChild-v1.1-2017EN" />
+    <identity value="hcim-developmentchild-v1.1-2017EN" />
     <uri value="https://zibs.nl/wiki/DevelopmentChild-v1.1(2017EN)" />
   </mapping>
   <kind value="resource" />
@@ -34,7 +34,7 @@
       <definition value="Information on the development and growth of a child is important in determining the kind of care that should be provided to the child and the family. When the child is being transferred, continuity of care can be achieved . Information can provide insight in the process of development and whether the child has a developmental delay." />
       <alias value="OntwikkelingKind" />
       <mapping>
-        <identity value="DevelopmentChild-v1.1-2017EN" />
+        <identity value="hcim-developmentchild-v1.1-2017EN" />
         <map value="NL-CM:4.32.1" />
         <comment value="DevelopmentChild" />
       </mapping>
@@ -50,7 +50,7 @@
       </slicing>
       <min value="1" />
       <mapping>
-        <identity value="hcim-DevelopmentChild-v1.1-2017EN" />
+        <identity value="hcim-developmentchild-v1.1-2017EN" />
         <map value="NL-CM:4.32.1" />
         <comment value="DevelopmentChild" />
       </mapping>
@@ -88,7 +88,7 @@
         <code value="dateTime" />
       </type>
       <mapping>
-        <identity value="DevelopmentChild-v1.1-2017EN" />
+        <identity value="hcim-developmentchild-v1.1-2017EN" />
         <map value="NL-CM:4.32.2" />
         <comment value="DevelopmentChildDateTime" />
       </mapping>
@@ -98,7 +98,7 @@
       <definition value="Comment on the development of the child." />
       <alias value="Toelichting" />
       <mapping>
-        <identity value="DevelopmentChild-v1.1-2017EN" />
+        <identity value="hcim-developmentchild-v1.1-2017EN" />
         <map value="NL-CM:4.32.3" />
         <comment value="Toelichting" />
       </mapping>
@@ -143,7 +143,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="DevelopmentChild-v1.1-2017EN" />
+        <identity value="hcim-developmentchild-v1.1-2017EN" />
         <map value="NL-CM:4.32.4" />
         <comment value="ToiletTrainednessUrine" />
       </mapping>
@@ -178,7 +178,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="DevelopmentChild-v1.1-2017EN" />
+        <identity value="hcim-developmentchild-v1.1-2017EN" />
         <map value="NL-CM:4.32.5" />
       </mapping>
     </element>
@@ -205,7 +205,7 @@
         <code value="dateTime" />
       </type>
       <mapping>
-        <identity value="DevelopmentChild-v1.1-2017EN" />
+        <identity value="hcim-developmentchild-v1.1-2017EN" />
         <map value="NL-CM:4.32.7" />
       </mapping>
     </element>
@@ -239,7 +239,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="DevelopmentChild-v1.1-2017EN" />
+        <identity value="hcim-developmentchild-v1.1-2017EN" />
         <map value="NL-CM:4.32.6" />
         <comment value="DevelopmentLocomotion" />
       </mapping>
@@ -274,7 +274,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="DevelopmentChild-v1.1-2017EN" />
+        <identity value="hcim-developmentchild-v1.1-2017EN" />
         <map value="NL-CM:4.32.8" />
         <comment value="DevelopmentSocial" />
       </mapping>
@@ -309,7 +309,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="DevelopmentChild-v1.1-2017EN" />
+        <identity value="hcim-developmentchild-v1.1-2017EN" />
         <map value="NL-CM:4.32.9" />
         <comment value="DevelopmentLinguistics" />
       </mapping>
@@ -344,7 +344,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="DevelopmentChild-v1.1-2017EN" />
+        <identity value="hcim-developmentchild-v1.1-2017EN" />
         <map value="NL-CM:4.32.10" />
         <comment value="DevelopmentCognition" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-Dispense.xml
+++ b/Profiles - ZIB 2017/zib-Dispense.xml
@@ -19,9 +19,9 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="hcim-dispense-v1.0-2017EN" />
-    <uri value="https://zibs.nl/wiki/Dispense-v1.0(2017EN)" />
-    <name value="HCIM Dispense-v1.0(2017EN)" />
+    <identity value="hcim-medicationdispense-v2.0-2017EN" />
+    <uri value="https://zibs.nl/wiki/MedicationDispense-v2.0(2017EN)" />
+    <name value="HCIM MedicationDispense-v2.0(2017EN)" />
   </mapping>
   <mapping>
     <identity value="Medication-Process-v09" />
@@ -45,7 +45,7 @@
       <short value="MedicationDispense" />
       <alias value="Verstrekking" />
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.20270" />
         <comment value="MedicationDispense" />
       </mapping>
@@ -73,7 +73,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Dispense-DistributionForm" />
       </type>
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.20927" />
         <comment value="DistributionForm" />
       </mapping>
@@ -102,7 +102,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Dispense-RequestDate" />
       </type>
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.2250" />
         <comment value="RequestDate" />
       </mapping>
@@ -119,7 +119,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Medication-AdditionalInformation" />
       </type>
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.23285" />
         <comment value="MedicationDispenseAdditionalInformation" />
       </mapping>
@@ -226,7 +226,7 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Product" />
       </type>
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.22259" />
         <comment value="DispensedMedicine" />
       </mapping>
@@ -264,7 +264,7 @@
       <definition value="In almost all cases, the supplier will be a pharmacist. It could also be supplied by a webshop (in case of an online order), a drug store or a foreign pharmacist." />
       <alias value="Verstrekker" />
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.20858" />
         <comment value="Supplier" />
       </mapping>
@@ -335,7 +335,7 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-DispenseRequest" />
       </type>
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.22396" />
         <comment value="DispenseRequest" />
       </mapping>
@@ -346,7 +346,7 @@
       <definition value="Number of units of the product (measured based on the relevant product code) supplied." />
       <alias value="VerstrekteHoeveelheid" />
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.20923" />
         <comment value="DispensedAmount" />
       </mapping>
@@ -357,7 +357,7 @@
       <definition value="The period in which the medication is expected to be used. The value depends on the dose and the dispensed amount." />
       <alias value="VerbruiksDuur" />
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.20924" />
         <comment value="DurationOfUse" />
       </mapping>
@@ -372,7 +372,7 @@
         <valueDateTime value="2017-05-17" />
       </example>
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.20272" />
         <comment value="MedicationDispenseDateTime" />
       </mapping>
@@ -392,7 +392,7 @@
         <targetProfile value="http://fhir.nl/fhir/StructureDefinition/nl-core-location" />
       </type>
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.20925" />
         <comment value="DispenseLocation. Use Location.name." />
       </mapping>
@@ -434,7 +434,7 @@
       <alias value="Toelichting" />
       <alias value="Aanvullende informatie" />
       <mapping>
-        <identity value="hcim-dispense-v1.0-2017EN" />
+        <identity value="hcim-medicationdispense-v2.0-2017EN" />
         <map value="NL-CM:9.9.22276" />
         <comment value="Comment" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-DispenseRequest.xml
+++ b/Profiles - ZIB 2017/zib-DispenseRequest.xml
@@ -19,14 +19,14 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="hcim-dispenserequest-v1.0-2017EN" />
-    <uri value="https://zibs.nl/wiki/DispenseRequest-v1.0(2017EN)" />
-    <name value="HCIM DispenseRequest-v1.0(2017EN)" />
+    <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
+    <uri value="https://zibs.nl/wiki/DispenseRequest-v1.0.1(2017EN)" />
+    <name value="HCIM DispenseRequest-v1.0.1(2017EN)" />
   </mapping>
   <mapping>
     <identity value="hcim-timeinterval-v1.0-2017EN" />
     <uri value="https://zibs.nl/wiki/TimeInterval-v1.0(2017EN)" />
-    <name value="HCIM Part TimeInterval-v1.0(2017EN)" />
+    <name value="HCIM TimeInterval-v1.0(2017EN)" />
   </mapping>
   <mapping>
     <identity value="Medication-Process-v09" />
@@ -50,7 +50,7 @@
       <short value="MedicationDispenseRequest" />
       <alias value="Verstrekkingsverzoek" />
       <mapping>
-        <identity value="hcim-dispenserequest-v1.0-2017EN" />
+        <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
         <map value="NL-CM:9.10.19963" />
         <comment value="DispenseRequest" />
       </mapping>
@@ -76,7 +76,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Medication-AdditionalInformation" />
       </type>
       <mapping>
-        <identity value="hcim-dispenserequest-v1.0-2017EN" />
+        <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
         <map value="NL-CM:9.10.22759" />
         <comment value="AdditionalWishes" />
       </mapping>
@@ -166,7 +166,7 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Product" />
       </type>
       <mapping>
-        <identity value="hcim-dispenserequest-v1.0-2017EN" />
+        <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
         <map value="NL-CM:9.10.22249" />
         <comment value="MedicineToBeDispensed" />
       </mapping>
@@ -204,7 +204,7 @@
       <definition value="Time at which the dispense request is entered." />
       <alias value="VerstrekkingsverzoekDatum" />
       <mapping>
-        <identity value="hcim-dispenserequest-v1.0-2017EN" />
+        <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
         <map value="NL-CM:9.10.20060" />
         <comment value="DispenseRequestDate" />
       </mapping>
@@ -297,7 +297,7 @@
       <definition value="Explanation for the dispense request. This explanation can contain e.g. information on why a prescriber submits a dispense request that deviates from the norm, e.g. an extra dispense request needed because the patient has lost the medication" />
       <alias value="Toelichting" />
       <mapping>
-        <identity value="hcim-dispenserequest-v1.0-2017EN" />
+        <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
         <map value="NL-CM:9.10.22274" />
         <comment value="Comment" />
       </mapping>
@@ -333,7 +333,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Dispense-Location" />
       </type>
       <mapping>
-        <identity value="hcim-dispenserequest-v1.0-2017EN" />
+        <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
         <map value="NL-CM:9.10.20068" />
         <comment value="DispenseLocation. Use Location.name for the location string" />
       </mapping>
@@ -344,7 +344,7 @@
       <definition value="During the approved period of use, the pharmacist has permission to dispense medicine so that the patient has a sufficient amount of medication. &#xD;&#xA;In many cases, the approved period of use can be described by only an end date: the approved end date of use." />
       <alias value="Verbruiksperiode" />
       <mapping>
-        <identity value="hcim-dispenserequest-v1.0-2017EN" />
+        <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
         <map value="NL-CM:9.10.20062" />
         <comment value="PeriodOfUse" />
       </mapping>
@@ -380,7 +380,7 @@
       <definition value="The number of additional times the medication may be dispensed after the first time.  The total amount that may be dispensed is: (Number of refills + 1) x amount to be dispensed." />
       <alias value="AantalHerhalingen" />
       <mapping>
-        <identity value="hcim-dispenserequest-v1.0-2017EN" />
+        <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
         <map value="NL-CM:9.10.22120" />
         <comment value="NumberOfRefills" />
       </mapping>
@@ -391,7 +391,7 @@
       <definition value="This is the number of units of the ordered product per dispense. &#xD;&#xA;The number of refills indicates how often this amount is allowed to be dispensed." />
       <alias value="TeVerstrekkenHoeveelheid" />
       <mapping>
-        <identity value="hcim-dispenserequest-v1.0-2017EN" />
+        <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
         <map value="NL-CM:9.10.19964" />
         <comment value="Amount" />
       </mapping>
@@ -401,7 +401,7 @@
       <short value="Duration" />
       <alias value="Duur" />
       <mapping>
-        <identity value="hcim-dispenserequest-v1.0-2017EN" />
+        <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
         <map value="NL-CM:9.10.20062" />
         <comment value="PeriodOfUse" />
       </mapping>
@@ -412,7 +412,7 @@
       <definition value="The intended supplier is a pharmacist." />
       <alias value="BeoogdVerstrekker" />
       <mapping>
-        <identity value="hcim-dispenserequest-v1.0-2017EN" />
+        <identity value="hcim-dispenserequest-v1.0.1-2017EN" />
         <map value="NL-CM:9.10.19966" />
         <comment value="IntendedSupplier" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-FreedomRestrictingMeasures-LegallyCapable.xml
+++ b/Profiles - ZIB 2017/zib-FreedomRestrictingMeasures-LegallyCapable.xml
@@ -21,7 +21,7 @@
   <mapping>
     <identity value="hcim-freedomrestrictingmeasures-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/FreedomRestrictingMeasures-v3.1(2017EN)" />
-    <name value="HCIM FreedomRestrictingMeasures-v3.1-(2017EN)" />
+    <name value="HCIM FreedomRestrictingMeasures-v3.1(2017EN)" />
   </mapping>
   <kind value="resource" />
   <abstract value="false" />

--- a/Profiles - ZIB 2017/zib-GeneralMeasurement.xml
+++ b/Profiles - ZIB 2017/zib-GeneralMeasurement.xml
@@ -19,7 +19,7 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="hcim-generalmeasurment-v3.0-2017EN" />
+    <identity value="hcim-generalmeasurement-v3.0-2017EN" />
     <uri value="https://zibs.nl/wiki/GeneralMeasurement-v3.0(2017EN)" />
     <name value="HCIM GeneralMeasurement-v3.0(2017EN)" />
   </mapping>
@@ -31,7 +31,7 @@
   <mapping>
     <identity value="hcim-outcomeofcare-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/OutcomeOfCare-v3.1(2017EN)" />
-    <name value="HCIM OutcomeOfCare-v3.1 (2017EN)" />
+    <name value="HCIM OutcomeOfCare-v3.1(2017EN)" />
   </mapping>
   <kind value="resource" />
   <abstract value="false" />
@@ -46,7 +46,7 @@
       <comment value="This profile is used both for the GeneralMeasurement concept and the MeasurementResult concept of HCIM GeneralMeasurement. A GeneralMeasurement can contain mutiple related MeasurementResults. This is implemented using a parent Observation with related child Observations. See the code and related elements." />
       <alias value="MeetUitslag" />
       <mapping>
-        <identity value="hcim-generalmeasurment-v3.0-2017EN" />
+        <identity value="hcim-generalmeasurement-v3.0-2017EN" />
         <map value="NL-CM:13.3.1" />
         <comment value="GeneralMeasurement" />
       </mapping>
@@ -71,7 +71,7 @@
               <display value="ResultStatusCodelist-to-ObservationStatus" />
             </valueReference>
           </extension>
-          <reference value="http://hl7.org/fhir/ValueSet/observation-status"/>
+          <reference value="http://hl7.org/fhir/ValueSet/observation-status" />
         </valueSetReference>
       </binding>
     </element>
@@ -108,7 +108,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-generalmeasurment-v3.0-2017EN" />
+        <identity value="hcim-generalmeasurement-v3.0-2017EN" />
         <map value="NL-CM:13.3.3" />
         <comment value="ResultStatus" />
       </mapping>
@@ -132,12 +132,12 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-generalmeasurment-v3.0-2017EN" />
+        <identity value="hcim-generalmeasurement-v3.0-2017EN" />
         <map value="NL-CM:13.3.2" />
         <comment value="Investigation" />
       </mapping>
       <mapping>
-        <identity value="hcim-generalmeasurment-v3.0-2017EN" />
+        <identity value="hcim-generalmeasurement-v3.0-2017EN" />
         <map value="NL-CM:13.3.6" />
         <comment value="MeasurementName" />
       </mapping>
@@ -148,7 +148,7 @@
       <definition value="Date and if possible the time at which the entire or specific result measurement was carried out." />
       <alias value="UitslagDatumTijd" />
       <mapping>
-        <identity value="hcim-generalmeasurment-v3.0-2017EN" />
+        <identity value="hcim-generalmeasurement-v3.0-2017EN" />
         <map value="NL-CM:13.3.9" />
         <comment value="ResultDateTime" />
       </mapping>
@@ -159,7 +159,7 @@
       <definition value="The result of the measurement. Depending on the type of measurement, the result will consist of a value with a unit or a coded value (ordinal or nominal) or of a textual result." />
       <alias value="UitslagWaarde" />
       <mapping>
-        <identity value="hcim-generalmeasurment-v3.0-2017EN" />
+        <identity value="hcim-generalmeasurement-v3.0-2017EN" />
         <map value="NL-CM:13.3.7" />
         <comment value="ResultValue" />
       </mapping>
@@ -170,7 +170,7 @@
       <definition value="Comments such as an interpretation or advice accompanying the result." />
       <alias value="Toelichting" />
       <mapping>
-        <identity value="hcim-generalmeasurment-v3.0-2017EN" />
+        <identity value="hcim-generalmeasurement-v3.0-2017EN" />
         <map value="NL-CM:13.3.4" />
         <comment value="Comment" />
       </mapping>
@@ -189,7 +189,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-generalmeasurment-v3.0-2017EN" />
+        <identity value="hcim-generalmeasurement-v3.0-2017EN" />
         <map value="NL-CM:13.3.8" />
         <comment value="MeasuringMethod" />
       </mapping>
@@ -201,7 +201,7 @@
       <comment value="The HCIM GeneralMeasurement (parent) links to every MeasurementResult (child) through the related.target reference. The referenced Observation contains all the concepts of the HCIM MeasurmentResult container, e.g. results with the name, resultvalue, methode, etc. This GeneralMeasurement profile is used for both Observations." />
       <alias value="MeetUitslag" />
       <mapping>
-        <identity value="hcim-generalmeasurment-v3.0-2017EN" />
+        <identity value="hcim-generalmeasurement-v3.0-2017EN" />
         <map value="NL-CM:13.3.5" />
         <comment value="MeasurementResult" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-HearingFunction-HearingAid-Product.xml
+++ b/Profiles - ZIB 2017/zib-HearingFunction-HearingAid-Product.xml
@@ -21,7 +21,7 @@
   <mapping>
     <identity value="hcim-hearingfunction-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/HearingFunction-v3.1(2017EN)" />
-    <name value="HCIM HearingFunction-v3.1-2017EN" />
+    <name value="HCIM HearingFunction-v3.1(2017EN)" />
   </mapping>
   <kind value="resource" />
   <abstract value="false" />

--- a/Profiles - ZIB 2017/zib-HearingFunction.xml
+++ b/Profiles - ZIB 2017/zib-HearingFunction.xml
@@ -21,7 +21,7 @@
   <mapping>
     <identity value="hcim-hearingfunction-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/HearingFunction-v3.1(2017EN)" />
-    <name value="HCIM HearingFunction-v3.1-2017EN" />
+    <name value="HCIM HearingFunction-v3.1(2017EN)" />
   </mapping>
   <kind value="resource" />
   <abstract value="false" />

--- a/Profiles - ZIB 2017/zib-IllnessPerception.xml
+++ b/Profiles - ZIB 2017/zib-IllnessPerception.xml
@@ -24,7 +24,7 @@
     <name value="HCIM BasicElements-v1.0(2017EN)" />
   </mapping>
   <mapping>
-    <identity value="hcim-IllnessPerception-v3.1-2017EN" />
+    <identity value="hcim-illnessperception-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/IllnessPerception-v3.1(2017EN)" />
     <name value="HCIM IllnessPerception-v3.1(2017EN)" />
   </mapping>
@@ -55,7 +55,7 @@
       <min value="1" />
       <max value="1" />
       <mapping>
-        <identity value="hcim-IllnessPerception-v3.1-2017EN" />
+        <identity value="hcim-illnessperception-v3.1-2017EN" />
         <map value="NL-CM:18.5.1" />
         <comment value="IllnessPerception" />
       </mapping>
@@ -100,7 +100,7 @@
       <short value="Patient Illness Insight" />
       <definition value="The patient’s illness insight describes their awareness of having an illness or health problem and what that means for their daily life." />
       <mapping>
-        <identity value="hcim-IllnessPerception-v3.1-2017EN" />
+        <identity value="hcim-illnessperception-v3.1-2017EN" />
         <map value="NL-CM:18.5.3" />
       </mapping>
     </element>
@@ -133,7 +133,7 @@
       <short value="Coping With Illness By Patient" />
       <definition value="The description of how the patient deals with their illness or health problem." />
       <mapping>
-        <identity value="hcim-IllnessPerception-v3.1-2017EN" />
+        <identity value="hcim-illnessperception-v3.1-2017EN" />
         <map value="NL-CM:18.5.4" />
         <comment value="CopingWithIllnessByPatient" />
       </mapping>
@@ -160,7 +160,7 @@
       <short value="Coping With Illness By Family" />
       <definition value="The description of how the family deals with the patient’s illness or health problem." />
       <mapping>
-        <identity value="hcim-IllnessPerception-v3.1-2017EN" />
+        <identity value="hcim-illnessperception-v3.1-2017EN" />
         <map value="NL-CM:18.5.5" />
         <comment value="CopingWithIllnessByFamily" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-InstructionsForUse.xml
+++ b/Profiles - ZIB 2017/zib-InstructionsForUse.xml
@@ -19,9 +19,9 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="hcim-instructionsforuse-v1.0-2017EN" />
-    <uri value="https://zibs.nl/wiki/InstructionsForUse-v1.0(2017EN)" />
-    <name value="HCIM InstructionsForUse-v1.0(2017EN)" />
+    <identity value="hcim-instructionsforuse-v1.1-2017EN" />
+    <uri value="https://zibs.nl/wiki/InstructionsForUse-v1.1(2017EN)" />
+    <name value="HCIM InstructionsForUse-v1.1(2017EN)" />
   </mapping>
   <kind value="complex-type" />
   <abstract value="false" />
@@ -36,7 +36,7 @@
       <comment value="The wiki page https://informatiestandaarden.nictiz.nl/wiki/mp:V9.0_Voorbeelden_doseringen provides dosage instruction examples. These examples consists of functional data and their representation in FHIR and CDA." />
       <alias value="Gebruiksinstructie" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.22504" />
         <comment value="InstructionsForUse" />
       </mapping>
@@ -47,7 +47,7 @@
       <definition value="This indicates the sequence of the dosing instructions within the medication agreement." />
       <alias value="Volgnummer" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.22503" />
         <comment value="SequenceNumber" />
       </mapping>
@@ -58,7 +58,7 @@
       <definition value="Textual description of the complete instructions for use including the period of use." />
       <alias value="Omschrijving" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.9581" />
         <comment value="Description" />
       </mapping>
@@ -79,7 +79,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19944" />
         <comment value="AdditionalInstructions" />
       </mapping>
@@ -115,12 +115,12 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.22512" />
         <comment value="AsNeeded" />
       </mapping>
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19945" />
         <comment value="Condition" />
       </mapping>
@@ -149,7 +149,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19941" />
         <comment value="RouteOfAdministration" />
       </mapping>
@@ -167,7 +167,7 @@
       <definition value="The dose indicates the dose amount per administration. &#xA; &#xA;The dosage is described in the unit accompanying the product; usually, this is just a number of units or doses. Liquids and other divisible products will usually include a unit of volume (preferably &quot;&quot;ml&quot;&quot;). &#xA; &#xA;In many cases, the prescriber will want to indicate the dose in units of weight of the active ingredient.  &#xA; &#xA;If only the ingredient is included and not the product, then the amount of that ingredient will be given. Paracetamol 1000mg is equivalent to 2 Paracetamol 500mg tablets or units. &#xA; &#xA;The dosage is sometimes given as a calculation, in which the patient’s body weight or body surface area is used as a parameter. The calculation is however no more than an aid in reaching a decision. &#xA; &#xA;In the event of constant administration, sometimes the dose is given in addition to the administration speed (infusion rate) (e.g. 20ml in a syringe or 500ml in a bag), but it is often also omitted. &#xA; &#xA;A general dosage recommendation such as ‘Use according to protocol’ or ‘See instructions’ can be sufficient. In that case, no dose is given." />
       <alias value="Keerdosis" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19940" />
         <comment value="Dose" />
       </mapping>
@@ -224,7 +224,7 @@
       <alias value="Maximale dosering" />
       <alias value="Maximale dosis (per dag enz.)" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19946" />
         <comment value="MaximumDose" />
       </mapping>
@@ -247,7 +247,7 @@
       <alias value="Toedieningssnelheid" />
       <alias value="Inloopsnelheid" />
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.19942" />
         <comment value="AdministeringSpeed" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-MedicalDeviceProduct.xml
+++ b/Profiles - ZIB 2017/zib-MedicalDeviceProduct.xml
@@ -36,7 +36,7 @@
   <mapping>
     <identity value="hcim-laboratorytestresult-v4.1-2017EN" />
     <uri value="https://zibs.nl/wiki/LaboratoryTestResult-v4.1(2017EN)" />
-    <name value="HCIM LaboratoryTestResultv4.1(2017EN)" />
+    <name value="HCIM LaboratoryTestResult-v4.1(2017EN)" />
   </mapping>
   <mapping>
     <identity value="hcim-basicelements-v1.0-2017EN" />

--- a/Profiles - ZIB 2017/zib-MedicationAdministration.xml
+++ b/Profiles - ZIB 2017/zib-MedicationAdministration.xml
@@ -19,9 +19,9 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
-    <uri value="https://zibs.nl/wiki/MedicationAdministration2-v1.0(2017EN)" />
-    <name value="HCIM MedicationAdministration2-v1.0(2017EN)" />
+    <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
+    <uri value="https://zibs.nl/wiki/MedicationAdministration2-v1.0.1(2017EN)" />
+    <name value="HCIM MedicationAdministration2-v1.0.1(2017EN)" />
   </mapping>
   <mapping>
     <identity value="Medication-Process-v09" />
@@ -61,7 +61,7 @@
       <definition value="Medication administration is the registration of the individual administrations of the medicine on the patient by the administrator (e.g. a nurse or patient themselves), in relation to the entered agreements." />
       <alias value="MedicatieToediening" />
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.20928" />
         <comment value="MedicationAdministration" />
       </mapping>
@@ -102,7 +102,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-MedicationAdministration-AgreedDateTime" />
       </type>
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.23171" />
         <comment value="AgreedDateTime" />
       </mapping>
@@ -119,7 +119,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-MedicationAdministration-DoubleCheckPerformed" />
       </type>
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.23168" />
         <comment value="DoubleCheckPerformed" />
       </mapping>
@@ -155,7 +155,7 @@
       <path value="MedicationAdministration.extension.extension" />
       <sliceName value="deviation" />
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.23167" />
         <comment value="DeviatingAdministration" />
       </mapping>
@@ -171,7 +171,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.23166" />
         <comment value="MedicationAdministrationReasonForDeviation" />
       </mapping>
@@ -190,7 +190,7 @@
       <definition value="The status of the administration, as a description of the stage within the administering process. Only the status codes ‘completed’ and ‘cancelled’ apply to indivisible products (such as tablets or suppositories). For divisible products (such as infusions), doses can also be ‘suspended’ or ‘aborted’. &#xD;&#xA;&#xD;&#xA;When documenting this, the following interpretations are used: &#xD;&#xA;Active: The product is administered.&#xD;&#xA;Interrupted: Use has (temporarily) been interrupted, because of a side effect, for example. Later, the patient and/or doctor can decide whether or not to resume or discontinue use.&#xD;&#xA;Discontinued: Administration has stopped.&#xD;&#xA;Completed: Administration has been completed.&#xD;&#xA;&#xD;&#xA;Not started: The product was never administered." />
       <alias value="MedicatieToedieningStatus" />
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.21191" />
         <comment value="MedicationAdministrationStatus" />
       </mapping>
@@ -281,7 +281,7 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Product" />
       </type>
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.20929" />
         <comment value="AdministrationProduct" />
       </mapping>
@@ -334,7 +334,7 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-MedicationAdministration" />
       </type>
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.23169" />
         <comment value="RelatedAgreement" />
       </mapping>
@@ -345,7 +345,7 @@
       <definition value="The date and time at which the medication was administered." />
       <alias value="ToedieningsDatumTijd" />
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.21193" />
         <comment value="AdministrationDateTime" />
       </mapping>
@@ -391,7 +391,7 @@
       <definition value="Container of the Administrator concept. This container contains all data elements of the Administrator concept. The concept describes the person who administered the product. This is a professional authorised administrator, the patient themselves or the caregiver, for example." />
       <alias value="Toediener" />
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.21196" />
         <comment value="Administrator" />
       </mapping>
@@ -421,17 +421,17 @@
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device" />
       </type>
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.23380" />
         <comment value="Patient" />
       </mapping>
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.23172" />
         <comment value="HealthProfessional" />
       </mapping>
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.23355" />
         <comment value="Caregiver" />
       </mapping>
@@ -468,7 +468,7 @@
       <definition value="Comments on administering the medication." />
       <alias value="Toelichting" />
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.21337" />
         <comment value="Comment" />
       </mapping>
@@ -491,7 +491,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.21195" />
         <comment value="RouteOfAdministration" />
       </mapping>
@@ -511,7 +511,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.21194" />
         <comment value="AdministeredAmount" />
       </mapping>
@@ -522,7 +522,7 @@
       <definition value="The administering speed is used in slow administration of liquid. In practice, the measuring unit is almost always ml/hour. &#xD;&#xA;Entering an interval (such as 0-10 ml/hour) is also a commonly used option. &#xD;&#xA;&#xD;&#xA;For example, with an administering speed of 10ml/hour: &#xD;&#xA;amount = 10,&#xD;&#xA;dose unit = ml&#xD;&#xA;&#xD;&#xA;time unit = hour" />
       <alias value="Toedieningssnelheid" />
       <mapping>
-        <identity value="hcim-MedicationAdministration2-v1.0-2017EN" />
+        <identity value="hcim-medicationadministration2-v1.0.1-2017EN" />
         <map value="NL-CM:9.13.23159" />
         <comment value="AdministeringSpeed" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-MedicationUse.xml
+++ b/Profiles - ZIB 2017/zib-MedicationUse.xml
@@ -19,14 +19,14 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="hcim-medicationuse2-v1.0-2017EN" />
-    <uri value="https://zibs.nl/wiki/MedicationUse2-v1.0(2017EN)" />
-    <name value="HCIM MedicationUse2-v1.0(2017EN)" />
+    <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
+    <uri value="https://zibs.nl/wiki/MedicationUse2-v1.0.1(2017EN)" />
+    <name value="HCIM MedicationUse2-v1.0.1(2017EN)" />
   </mapping>
   <mapping>
     <identity value="hcim-timeinterval-v1.0-2017EN" />
     <uri value="https://zibs.nl/wiki/TimeInterval-v1.0(2017EN)" />
-    <name value="HCIM Part TimeInterval-v1.0(2017EN)" />
+    <name value="HCIM TimeInterval-v1.0(2017EN)" />
   </mapping>
   <mapping>
     <identity value="Medication-Process-v09" />
@@ -35,9 +35,9 @@
     <comment value="Language of Medication Process is Dutch." />
   </mapping>
   <mapping>
-    <identity value="hcim-instructionsforuse-v1.0-2017EN" />
-    <uri value="https://zibs.nl/wiki/InstructionsForUse-v1.0(2017EN)" />
-    <name value="HCIM InstructionsForUse-v1.0(2017EN)" />
+    <identity value="hcim-instructionsforuse-v1.1-2017EN" />
+    <uri value="https://zibs.nl/wiki/InstructionsForUse-v1.1(2017EN)" />
+    <name value="HCIM InstructionsForUse-v1.1(2017EN)" />
   </mapping>
   <mapping>
     <identity value="hcim-basicelements-v1.0-2017EN" />
@@ -56,7 +56,7 @@
       <definition value="MedicationUse is a statement on the historic, current or intended use of a certain medicine." />
       <alias value="Medicatiegebruik" />
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.21338" />
         <comment value="MedicationUse" />
       </mapping>
@@ -83,7 +83,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-MedicationUse-AsAgreedIndicator" />
       </type>
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.22492" />
         <comment value="AsAgreedIndicator" />
       </mapping>
@@ -108,7 +108,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-MedicationUse-Prescriber" />
       </type>
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.23290" />
         <comment value="Prescriber" />
       </mapping>
@@ -178,7 +178,7 @@
         <strength value="extensible" />
       </binding>
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.22493" />
         <comment value="Reden wijzigen of stoppen gebruik" />
       </mapping>
@@ -205,7 +205,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Medication-RepeatPeriodCyclicalSchedule" />
       </type>
       <mapping>
-        <identity value="hcim-instructionsforuse-v1.0-2017EN" />
+        <identity value="hcim-instructionsforuse-v1.1-2017EN" />
         <map value="NL-CM:9.12.22505" />
         <comment value="RepeatPeriodCyclicalSchedule" />
       </mapping>
@@ -225,7 +225,7 @@
       <alias value="MedicatieGebruikStopType" />
       <binding>
         <strength value="required" />
-        <description value="Allergy Intolerance critically Code list"/>
+        <description value="Allergy Intolerance critically Code list" />
         <valueSetReference>
           <extension url="http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap">
             <valueReference>
@@ -233,11 +233,11 @@
               <display value="MedicationUseStopTypeCodeLijst-to-MedicationStatementStatus" />
             </valueReference>
           </extension>
-          <reference value="http://hl7.org/fhir/ValueSet/medication-statement-status"/>
+          <reference value="http://hl7.org/fhir/ValueSet/medication-statement-status" />
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.23132" />
         <comment value="MedicationUseStopType. A ConceptMap (http://nictiz.nl/fhir/ConceptMap/MedicationUseStopTypeCodeLijst-to-MedicationStatementStatus) is available that maps MedicationUseStopTypeCodeLijst to the MedicationStatementStatus valueset." />
       </mapping>
@@ -281,7 +281,7 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Product" />
       </type>
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.21339" />
         <comment value="ProductUsed" />
       </mapping>
@@ -296,7 +296,7 @@
         <code value="Period" />
       </type>
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.22663" />
         <comment value="PeriodOfUse" />
       </mapping>
@@ -374,7 +374,7 @@
         <valueDateTime value="2017-06-14" />
       </example>
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.22398" />
         <comment value="MedicationUseDateTime" />
       </mapping>
@@ -445,7 +445,7 @@
         <valueCode value="y" />
       </example>
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.22399" />
         <comment value="UseIndicator" />
       </mapping>
@@ -456,7 +456,7 @@
       <definition value="The reason for using the medication, particularly in self-care medicine purchased by the patient themselves." />
       <alias value="RedenGebruik" />
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.22491" />
         <comment value="ReasonForUse" />
       </mapping>
@@ -467,7 +467,7 @@
       <definition value="Comments on the medication use." />
       <alias value="Toelichting" />
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.21624" />
         <comment value="Comment" />
       </mapping>
@@ -479,7 +479,7 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-InstructionsForUse" />
       </type>
       <mapping>
-        <identity value="hcim-medicationuse2-v1.0-2017EN" />
+        <identity value="hcim-medicationuse2-v1.0.1-2017EN" />
         <map value="NL-CM:9.11.22504" />
         <comment value="InstructionsForUse" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-Respiration-AdministeredOxygen-AdministrationDeviceProduct.xml
+++ b/Profiles - ZIB 2017/zib-Respiration-AdministeredOxygen-AdministrationDeviceProduct.xml
@@ -21,7 +21,7 @@
   <mapping>
     <identity value="hcim-respiration-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/Respiration-v3.1(2017EN)" />
-    <name value="HCIM Respiration-v3.12017-EN" />
+    <name value="HCIM Respiration-v3.1(2017EN)" />
   </mapping>
   <kind value="resource" />
   <abstract value="false" />

--- a/Profiles - ZIB 2017/zib-Respiration-AdministeredOxygen.xml
+++ b/Profiles - ZIB 2017/zib-Respiration-AdministeredOxygen.xml
@@ -21,7 +21,7 @@
   <mapping>
     <identity value="hcim-respiration-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/Respiration-v3.1(2017EN)" />
-    <name value="HCIM Respiration-v3.12017-EN" />
+    <name value="HCIM Respiration-v3.1(2017EN)" />
   </mapping>
   <kind value="complex-type" />
   <abstract value="false" />

--- a/Profiles - ZIB 2017/zib-Respiration.xml
+++ b/Profiles - ZIB 2017/zib-Respiration.xml
@@ -21,7 +21,7 @@
   <mapping>
     <identity value="hcim-respiration-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/Respiration-v3.1(2017EN)" />
-    <name value="HCIM Respiration-v3.12017-EN" />
+    <name value="HCIM Respiration-v3.1(2017EN)" />
   </mapping>
   <kind value="resource" />
   <abstract value="false" />

--- a/Profiles - ZIB 2017/zib-SkinDisorder.xml
+++ b/Profiles - ZIB 2017/zib-SkinDisorder.xml
@@ -19,7 +19,7 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="zib-skindisorder-v3.2-2017EN" />
+    <identity value="hcim-skindisorder-v3.2-2017EN" />
     <uri value="https://zibs.nl/wiki/SkinDisorder-v3.2(2017EN)" />
     <name value="HCIM SkinDisorder-v3.2(2017EN)" />
   </mapping>
@@ -35,7 +35,7 @@
       <definition value="A skin condition is a disturbance of the organ skin caused by a source to be specified later on." />
       <alias value="Huidaandoening" />
       <mapping>
-        <identity value="zib-skindisorder-v3.2-2017EN" />
+        <identity value="hcim-skindisorder-v3.2-2017EN" />
         <map value="NL-CM:19.3.1" />
         <comment value="SkinDisorder" />
       </mapping>
@@ -74,7 +74,7 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem" />
       </type>
       <mapping>
-        <identity value="SkinDisorder-v3.2-2017EN" />
+        <identity value="hcim-skindisorder-v3.2-2017EN" />
         <map value="NL-CM:19.3.7" />
         <comment value="Cause" />
       </mapping>
@@ -133,11 +133,11 @@
         <description value="SoortAandoeningCodelijst" />
         <valueSetReference>
           <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.19.3.1--20171231000000" />
-        <display value="SoortAandoeningCodelijst"/>
+          <display value="SoortAandoeningCodelijst" />
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="zib-skindisorder-v3.2-2017EN" />
+        <identity value="hcim-skindisorder-v3.2-2017EN" />
         <map value="NL-CM:19.3.2" />
         <comment value="TypeOfDisorder" />
       </mapping>
@@ -156,7 +156,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="SkinDisorder-v3.2-2017EN" />
+        <identity value="hcim-skindisorder-v3.2-2017EN" />
         <map value="NL-CM:19.3.4" />
         <comment value="AnatomicalLocation" />
       </mapping>
@@ -191,11 +191,11 @@
         <description value="HuidLateraliteitCodelijst" />
         <valueSetReference>
           <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.19.3.3--20171231000000" />
-            <display value="HuidLateraliteitCodelijst"/>
+            <display value="HuidLateraliteitCodelijst" />
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="zib-skindisorder-v3.2-2017EN" />
+        <identity value="hcim-skindisorder-v3.2-2017EN" />
         <map value="NL-CM:19.3.8" />
         <comment value="Laterality" />
       </mapping>
@@ -210,18 +210,18 @@
         <code value="dateTime" />
       </type>
       <mapping>
-        <identity value="zib-skindisorder-v3.2-2017EN" />
+        <identity value="hcim-skindisorder-v3.2-2017EN" />
         <map value="NL-CM:19.3.3" />
         <comment value="DateOfOnset" />
       </mapping>
     </element>
     <element id="Condition.note">
       <path value="Condition.note" />
-      <short value="Comment"/>
+      <short value="Comment" />
       <definition value="A comment on the skin condition and how to care for it." />
-      <alias value="Toelichting"/>
+      <alias value="Toelichting" />
       <mapping>
-        <identity value="SkinDisorder-v3.2-2017EN" />
+        <identity value="hcim-skindisorder-v3.2-2017EN" />
         <map value="NL-CM:19.3.6" />
         <comment value="Comment" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-Wound-MedicalDevice.xml
+++ b/Profiles - ZIB 2017/zib-Wound-MedicalDevice.xml
@@ -10,7 +10,7 @@
   <purpose value="Profiles purpose is to define the usage of a wounddrain." />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="zib-wound-v3.1-2017EN" />
+    <identity value="hcim-wound-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/Wound-v3.1(2017EN)" />
     <name value="HCIM Wound-v3.1(2017EN)" />
   </mapping>
@@ -23,7 +23,7 @@
     <element id="DeviceUseStatement">
       <path value="DeviceUseStatement" />
       <mapping>
-        <identity value="Wound-v3.1-2017EN" />
+        <identity value="hcim-wound-v3.1-2017EN" />
         <map value="NL-CM:19.2.17" />
         <comment value="MedicalDevice" />
       </mapping>
@@ -35,7 +35,7 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Wound-MedicalDeviceProduct" />
       </type>
       <mapping>
-        <identity value="Wound-v3.1-2017EN" />
+        <identity value="hcim-wound-v3.1-2017EN" />
         <map value="NL-CM:10.1.3" />
         <comment value="Follow reference for ProductType" />
       </mapping>

--- a/Profiles - ZIB 2017/zib-Wound-MedicalDeviceProduct.xml
+++ b/Profiles - ZIB 2017/zib-Wound-MedicalDeviceProduct.xml
@@ -14,9 +14,9 @@
   <copyright value="CC0" />
   <fhirVersion value="3.0.2" />
   <mapping>
-    <identity value="zib-wound-v3.1-2017EN" />
+    <identity value="hcim-wound-v3.1-2017EN" />
     <uri value="https://zibs.nl/wiki/Wound-v3.1(2017EN)" />
-    <name value="Wound-v3.1(2017EN)" />
+    <name value="HCIM Wound-v3.1(2017EN)" />
   </mapping>
   <kind value="resource" />
   <abstract value="false" />
@@ -35,7 +35,7 @@
         </valueSetReference>
       </binding>
       <mapping>
-        <identity value="zib-wound-v3.1-2017EN" />
+        <identity value="hcim-wound-v3.1-2017EN" />
         <map value="NL-CM:10.1.3" />
         <comment value="ProductType" />
       </mapping>


### PR DESCRIPTION
References to 2017 HCIM now all have the correct version number and follow the naming convention: "hcim-" + lower-case(English alias) + "-v" + version number + "-" + year + "EN".
E.g.:  hcim-addressinformation-v1.0-2017EN