### PR TITLE
MM-2291: Remove incorrect double mappings:

### DIFF
--- a/Profiles - ZIB 2017/nl-core-relatedperson.xml
+++ b/Profiles - ZIB 2017/nl-core-relatedperson.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="nl-core-relatedperson" />
   <url value="http://fhir.nl/fhir/StructureDefinition/nl-core-relatedperson" />
@@ -183,9 +184,6 @@
       <definition value="Defines the contact’s familial relationship to the patient." />
       <alias value="Relatie" />
       <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="PatientRelationshipType" />
-        </extension>
         <strength value="extensible" />
         <valueSetReference>
           <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.3.1.1--20171231000000" />
@@ -250,8 +248,6 @@
     </element>
     <element id="RelatedPerson.telecom">
       <path value="RelatedPerson.telecom" />
-      <short value="ContactInformation" />
-      <alias value="Contactgegevens" />
       <type>
         <code value="ContactPoint" />
         <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-contactpoint" />
@@ -270,21 +266,6 @@
         <identity value="hcim-contactperson-v3.1-2017EN" />
         <map value="NL-CM:3.1.6" />
         <comment value="ContactInformation" />
-      </mapping>
-      <mapping>
-        <identity value="hcim-contactinformation-v2.0.1-2015EN" />
-        <map value="NL-CM:0.1.5" />
-        <comment value="ContactInformation" />
-      </mapping>
-      <mapping>
-        <identity value="hcim-contactinformation-v3.0-2016EN" />
-        <map value="NL-CM:0.1.5" />
-        <comment value="ContactInformation" />
-      </mapping>
-      <mapping>
-        <identity value="hcim-contactinformation-v1.0-2017EN" />
-        <map value="NL-CM:20.6.4" />
-        <comment value="TelephoneNumber" />
       </mapping>
       <mapping>
         <identity value="hcim-payer-v1.2-2015EN" />

--- a/Profiles - ZIB 2017/zib-FreedomRestrictingMeasures.xml
+++ b/Profiles - ZIB 2017/zib-FreedomRestrictingMeasures.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="zib-FreedomRestrictingMeasures" />
   <url value="http://nictiz.nl/fhir/StructureDefinition/zib-FreedomRestrictingMeasures" />
@@ -203,11 +204,6 @@
     <element id="Procedure.category">
       <path value="Procedure.category" />
       <min value="1" />
-      <mapping>
-        <identity value="hcim-freedomrestrictingmeasures-v3.1-2017EN" />
-        <map value="NL-CM:14.3.6" />
-        <comment value="TypeOfIntervention" />
-      </mapping>
     </element>
     <element id="Procedure.category.coding">
       <path value="Procedure.category.coding" />
@@ -219,11 +215,6 @@
         <rules value="open" />
       </slicing>
       <min value="1" />
-      <mapping>
-        <identity value="hcim-freedomrestrictingmeasures-v3.1-2017EN" />
-        <map value="NL-CM:14.3.6" />
-        <comment value="TypeOfIntervention" />
-      </mapping>
     </element>
     <element id="Procedure.category.coding:freedomRestrictingMeasuresCode">
       <path value="Procedure.category.coding" />
@@ -242,9 +233,6 @@
       <fixedCode value="225214000" />
     </element>
     <element id="Procedure.category.coding:freedomRestrictingMeasuresCode.display">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
-      </extension>
       <path value="Procedure.category.coding.display" />
       <defaultValueString value="Procedures relating to control, restraint, seclusion and segregation (procedure)" />
     </element>

--- a/Profiles - ZIB 2017/zib-Vaccination.xml
+++ b/Profiles - ZIB 2017/zib-Vaccination.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="zib-Vaccination" />
   <url value="http://nictiz.nl/fhir/StructureDefinition/zib-Vaccination" />
@@ -406,24 +407,6 @@
         <code value="Extension" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference" />
       </type>
-    </element>
-    <element id="Immunization.note">
-      <path value="Immunization.note" />
-      <mapping>
-        <identity value="hcim-vaccination-v1.2-2015EN" />
-        <map value="NL-CM:11.1.7" />
-        <comment value="Explanation" />
-      </mapping>
-      <mapping>
-        <identity value="hcim-vaccination-v3.0-2016EN" />
-        <map value="NL-CM:11.1.7" />
-        <comment value="Explanation" />
-      </mapping>
-      <mapping>
-        <identity value="hcim-vaccination-v3.1-2017EN" />
-        <map value="NL-CM:11.1.7" />
-        <comment value="Comment" />
-      </mapping>
     </element>
     <element id="Immunization.note.text">
       <path value="Immunization.note.text" />


### PR DESCRIPTION
- Remove NL-CM:11.1.7 on `Immunization.note` in profile zib-Vaccination
- Remove NL-CM:14.3.6 on `Procedure.category` and `Procedure.category.coding` in profile zib-FreedomRestrictingMeasures
- Remove NL-CM:20.6.4 on `RelatedPerson.telecom` in profile nl-core-relatedperson.