### PR TITLE
Revert "MM-2461: Temporary add the base ValueSet references to the pr…

### DIFF
--- a/Profiles - ZIB 2017/zib-AllergyIntolerance.xml
+++ b/Profiles - ZIB 2017/zib-AllergyIntolerance.xml
@@ -88,7 +88,6 @@
               <display value="AllergieStatusCodelijst-to-allergy-status" />
             </valueReference>
           </extension>
-          <reference value="http://hl7.org/fhir/ValueSet/allergy-clinical-status"/>
         </valueSetReference>
       </binding>
       <mapping>
@@ -170,7 +169,6 @@
               <display value="AllergieCategorieCodelijst-to-allergy-intolerance-category" />
             </valueReference>
           </extension>
-          <reference value="http://hl7.org/fhir/ValueSet/allergy-verification-status"/>
         </valueSetReference>
       </binding>
     </element>
@@ -236,7 +234,6 @@
               <display value="MateVanKritiekZijnCodelijst-to-allergy-intolerance-criticality" />
             </valueReference>
           </extension>
-          <reference value="http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality"/>
         </valueSetReference>
       </binding>
     </element>
@@ -875,7 +872,6 @@
               <display value="ErnstCodelijst-to-AllergyIntoleranceSeverity" />
             </valueReference>
           </extension>
-          <reference value="http://hl7.org/fhir/ValueSet/reaction-event-severity"/>
         </valueSetReference>
       </binding>
       <mapping>

--- a/Profiles - ZIB 2017/zib-BodyHeight.xml
+++ b/Profiles - ZIB 2017/zib-BodyHeight.xml
@@ -76,7 +76,6 @@
               <display value="PositieCodelijst-to-LOINC" />
             </valueReference>
           </extension>
-          <reference value="http://hl7.org/fhir/ValueSet/observation-vitalsignresult"/>
         </valueSetReference>
       </binding>
       <mapping>


### PR DESCRIPTION
…ofile differentials of zib-AllergyIntolerance and zib-BodyHeight to work around the broken package generator on Simplifier."

This reverts commit b1eb0cc1bab8a0a9d97b171d35d10b6ab8e13e73.

This should be fixed on Simplifier now, so this edit is no longer needed.