### PR TITLE
MM-2916: Removed redundant comments from IHE profiles

### DIFF
--- a/Profiles - ZIB 2017/IHE.MHD.DocumentManifest.xml
+++ b/Profiles - ZIB 2017/IHE.MHD.DocumentManifest.xml
@@ -101,7 +101,7 @@
     </element>
     <element id="DocumentManifest.related">
       <path value="DocumentManifest.related" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values." />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
   </differential>

--- a/Profiles - ZIB 2017/IHE.MHD.List.xml
+++ b/Profiles - ZIB 2017/IHE.MHD.List.xml
@@ -61,37 +61,37 @@
     </element>
     <element id="List.encounter">
       <path value="List.encounter" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values." />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
     <element id="List.source">
       <path value="List.source" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values." />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
     <element id="List.orderedBy">
       <path value="List.orderedBy" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values." />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
     <element id="List.entry.flag">
       <path value="List.entry.flag" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values." />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
     <element id="List.entry.deleted">
       <path value="List.entry.deleted" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values." />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
     <element id="List.entry.date">
       <path value="List.entry.date" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values." />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
     <element id="List.emptyReason">
       <path value="List.emptyReason" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values." />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
   </differential>

--- a/Profiles - ZIB 2017/IHE.MHD.Minimal.DocumentReference.xml
+++ b/Profiles - ZIB 2017/IHE.MHD.Minimal.DocumentReference.xml
@@ -50,7 +50,7 @@
     </element>
     <element id="DocumentReference.docStatus">
       <path value="DocumentReference.docStatus" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers&#xD;&#xA;should be robust to these elements holding values" />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
     <element id="DocumentReference.type">
@@ -106,7 +106,7 @@
     </element>
     <element id="DocumentReference.custodian">
       <path value="DocumentReference.custodian" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values." />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
     <element id="DocumentReference.relatesTo">
@@ -143,7 +143,7 @@
     </element>
     <element id="DocumentReference.content.attachment.data">
       <path value="DocumentReference.content.attachment.data" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values." />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
     <element id="DocumentReference.content.attachment.url">
@@ -170,7 +170,7 @@
     </element>
     <element id="DocumentReference.content.attachment.creation">
       <path value="DocumentReference.content.attachment.creation" />
-      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present. Document Consumers should be robust to these elements holding values." />
+      <comment value="These HL7 FHIR STU3 elements are not used in XDS, therefore would not be present." />
       <max value="0" />
     </element>
     <element id="DocumentReference.content.format">

--- a/Profiles - ZIB 2017/IHE.MHD.Minimal.DocumentReference.xml
+++ b/Profiles - ZIB 2017/IHE.MHD.Minimal.DocumentReference.xml
@@ -97,7 +97,7 @@
     </element>
     <element id="DocumentReference.authenticator">
       <path value="DocumentReference.authenticator" />
-      <comment value="Contained resource " />
+      <comment value="Contained resource" />
       <type>
         <code value="Reference" />
         <aggregation value="contained" />


### PR DESCRIPTION
In the IHE List profile there were also several redundant comments present on elements with maximum cardinality 0, so I removed these as well in a separate commit (so that it can easily be reverted, if necessary).