### PR TITLE
ZIBFHIR-370: Move reference to zib-TextResult in Procedure.report to …

### DIFF
--- a/Profiles - ZIB 2017/zib-Procedure.xml
+++ b/Profiles - ZIB 2017/zib-Procedure.xml
@@ -493,7 +493,18 @@
       </mapping>
     </element>
     <element id="Procedure.report">
+      <path value="Procedure.report"/>
+      <slicing>
+        <discriminator>
+          <type value="profile"/>
+          <path value="resolve()"/>
+        </discriminator>
+        <rules value="open"/>
+      </slicing>
+    </element>
+    <element id="Procedure.report:textResult">
       <path value="Procedure.report" />
+      <sliceName value="textResult"/>
       <definition value="Any report resulting from the procedure." />
       <comment value="Note that the HCIM TextResultForTransfer-v1.2 has this relationship reversed, so the relationship goes from report to procedure." />
       <type>


### PR DESCRIPTION
…a slice so the base .report element is unrestricted.